### PR TITLE
Make analysis run on Travis Pull Requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
       # Golang image - primary
       - image: golang:1.12.9-alpine3.10
 
-    working_directory: /code
+    working_directory: ~/repo
 
     steps:
       - run:
@@ -16,7 +16,7 @@ jobs:
             echo "https://mirror.csclub.uwaterloo.ca/alpine/v3.10/community" >>/etc/apk/repositories
             apk update
             apk add bash curl git openssh
-            mkdir /code
+            mkdir /code -p
 
       - checkout
 

--- a/git.go
+++ b/git.go
@@ -2,12 +2,31 @@ package main
 
 import (
 	"bytes"
+	"os"
 	"os/exec"
 	"strings"
 )
 
 // gitGetHead accepts a git directory and returns head commit OID / error
 func gitGetHead(workspaceDir string) (string, error) {
+	// Get USER env variable.
+	envUser := os.Getenv("USER")
+	if envUser == "travis" {
+		// Travis creates a merge commit for pull requests on forks.
+		// The head of commit is this merge commit, which does not match the commit of deepsource check.
+
+		// Fetch value of pull request SHA. If this is a PR, it will return SHA of HEAD commit of the PR, else "".
+		prSHA := os.Getenv("TRAVIS_PULL_REQUEST_SHA")
+
+		// If prSHA is not empty, that means we got an SHA, which is HEAD. Return this.
+		if len(prSHA) > 0 {
+			return prSHA, nil
+		}
+
+	}
+
+	// If we are here, it means either this is not a travis env, or this is not a travis PR.
+	// Continue to fetch the headOID via the git command.
 	headOID := ""
 
 	cmd := exec.Command("git", "--no-pager", "rev-parse", "HEAD")


### PR DESCRIPTION
### Why?
For every PR `Travis` creates a merge commit, and the Head, as well as commit of the build, is this merge commit.
Now, the DeepSource check is created for the actual HEAD commit of the PR, hence there is a commit mismatch and the artifact push is not successful. Hence the `Test Coverage` analyzer is never triggered.

This PR fixes this.

Circle Ci does not have this complication. It works with forks. Verified.