### PR TITLE
Use goreleaser supplied version flag

### DIFF
--- a/cmd/deepsource/main.go
+++ b/cmd/deepsource/main.go
@@ -6,14 +6,14 @@ import (
 	"os"
 
 	"github.com/deepsourcelabs/cli/command"
-	"github.com/deepsourcelabs/cli/version"
+	v "github.com/deepsourcelabs/cli/version"
 	"github.com/getsentry/sentry-go"
 	"github.com/pterm/pterm"
 )
 
 var (
 	// Version is the build version.  This is set using ldflags -X
-	Version = "development"
+	version = "development"
 
 	// Date is the build date.  This is set using ldflags -X
 	Date = "YYYY-MM-DD" // YYYY-MM-DD
@@ -33,7 +33,7 @@ func main() {
 		fmt.Println("Could not load sentry.")
 	}
 
-	version.SetBuildInfo(Version, Date, "", "")
+	v.SetBuildInfo(version, Date, "", "")
 
 	if err := command.Execute(); err != nil {
 		// TODO: Handle exit codes here


### PR DESCRIPTION
Goreleaser already supplies a `version` [ldflag](https://goreleaser.com/environment/#using-the-mainversion), therefore it will be better to use it instead of setting the version ourselves everytime.

Signed-off-by: siddhant-deepsource <siddhant@deepsource.io>