### PR TITLE
Add goreleaser workflow to publish homebrew tap

### DIFF
--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -37,6 +37,7 @@ brews:
   - tap:
       owner: deepsourcelabs
       name: homebrew-cli
+      token: "{{ .Env.GITHUB_TOKEN }}"
     commit_author:
       name: spock1966
       email: spock1966@deepsource.io

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -37,7 +37,7 @@ brews:
   - name: deepsource
   - tap:
       owner: deepsourcelabs
-      name: homebrew-deepsource
+      name: homebrew-cli
     commit_author:
       name: spock1966
       email: spock1966@deepsource.io

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -32,3 +32,15 @@ changelog:
   filters:
     exclude:
     - '^tests:'
+
+brews:
+  - tap:
+      owner: deepsourcelabs
+      name: homebrew-deepsource
+    commit_author:
+      name: spock1966
+      email: spock1966@deepsource.io
+    homepage: "https://github.com/deepsourcelabs/cli"
+    description: "Command line interface to DeepSource"
+    license: "BSD 2-Clause \"Simplified\" License"
+    skip_upload: auto

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -14,7 +14,6 @@ builds:
     goarch:
       - 386
       - amd64
-      - arm
       - arm64
     ldflags:
       - "-X 'main.version={{ .Version }}' -X 'main.SentryDSN={{ .Env.DEEPSOURCE_CLI_SENTRY_DSN }}'"

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -34,6 +34,7 @@ changelog:
     - '^tests:'
 
 brews:
+  - name: deepsource
   - tap:
       owner: deepsourcelabs
       name: homebrew-deepsource


### PR DESCRIPTION
Post the publishing of the tap, the CLI can be installed using `brew` using the following command :

```
brew install deepsourcelabs/cli/deepsource
```
OR
```
brew tap deepsourcelabs/cli
brew install deepsource
```
The tap will be published in https://github.com/deepsourcelabs/homebrew-cli

Signed-off-by: siddhant-deepsource <siddhant@deepsource.io>