### PR TITLE
the comma was not needed at the end of the object

### DIFF
--- a/command/root.go
+++ b/command/root.go
@@ -19,7 +19,7 @@ Now ship good code directly from the command line.
 
 Login into DeepSource using the command : deepsource auth login`,
 		SilenceErrors: true,
-		SilenceUsage:  true,
+		SilenceUsage:  true
 	}
 
 	// Child Commands


### PR DESCRIPTION
There was a not needed "," at deepsourcelabs/cli/command/root.go