### PR TITLE
chore: push homebrew tap to branch other than master

### DIFF
--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -36,6 +36,7 @@ brews:
   - tap:
       owner: deepsourcelabs
       name: homebrew-cli
+      branch: "cli-v{{ .Tag }}"
       token: "{{ .Env.HOMEBREW_TOKEN }}"
     commit_author:
       name: deepsourcebot


### PR DESCRIPTION
Goreleaser now allows pushing homebrew taps to branches other than the default branch. [Ref](https://goreleaser.com/customization/homebrew/).

Pushing to a different branch will help to verify the changes being pushed and then a pull request can be created in the [homebrew tap repository](https://github.com/deepsourcelabs/homebrew-cli) to merge the changes to master.

Signed-off-by: Siddhant N Trivedi <siddhant@deepsource.io>