### PR TITLE
fix(utils): add support for PAT based remote URLs

### DIFF
--- a/command/repo/status/status.go
+++ b/command/repo/status/status.go
@@ -74,7 +74,7 @@ func (opts *RepoStatusOptions) Run() (err error) {
 	if statusResponse.Activated {
 		pterm.Info.Println("Analysis active on DeepSource (deepsource.io)")
 	} else {
-		pterm.Info.Println("DeepSource analysis is currently not actived on this repository.")
+		pterm.Info.Println("DeepSource analysis is currently not activated on this repository.")
 	}
 	return nil
 }

--- a/utils/fetch_remote.go
+++ b/utils/fetch_remote.go
@@ -77,7 +77,6 @@ func ListRemotes() (map[string][]string, error) {
 
 		// git@ ssh urls
 		if strings.HasPrefix(remoteURL, "git@") {
-
 			pathURL := strings.Split(remoteURL, ":")
 			newPathURL := pathURL[1]
 			u, err := url.Parse(newPathURL)
@@ -87,13 +86,9 @@ func ListRemotes() (map[string][]string, error) {
 			splitPath := strings.Split(u.Path, "/")
 			owner = splitPath[0]
 		} else if strings.HasPrefix(remoteURL, "https://") {
-			u, err := url.Parse(remoteURL)
-			if err != nil {
-				continue
-			}
-			splitPath := strings.Split(u.Path, "/")
-
-			owner = splitPath[0]
+			remoteRegexp := regexp.MustCompile(`.+//(.+)/(.+)/(.+)(\.git)?$`)
+			matched := remoteRegexp.FindStringSubmatch(remoteURL)
+			owner = matched[2]
 		}
 
 		// owner, err := runCmd("git", []string{"config", "--get", "--null", "user.name"})

--- a/utils/fetch_remote_test.go
+++ b/utils/fetch_remote_test.go
@@ -11,12 +11,19 @@ var remotesPATMap = map[string][]string{
 }
 var remotesPATList = []string{"origin	https://username:ghp_pat@github.com/username/repo (fetch)", "origin	https://username:ghp_pat@github.com/username/repo (push)"}
 
+// Test data for multiple remotes with PATs
+var multiRemotePATMap = map[string][]string{
+	"origin":   {"username", "repo", "GITHUB", "username/repo"},
+	"upstream": {"company", "repo", "GITHUB", "company/repo"},
+}
+var multiRemotePATList = []string{"origin	https://username:ghp_pat@github.com/username/repo (fetch)", "origin	https://username:ghp_pat@github.com/username/repo (push)", "upstream	https://username:ghp_pat@github.com/company/repo (fetch)", "upstream	https://username:ghp_pat@github.com/company/repo (push)"}
+
 // Test data for multiple remotes
 var multiRemoteMap = map[string][]string{
 	"origin":   {"username", "repo", "GITHUB", "username/repo"},
 	"upstream": {"company", "repo", "GITHUB", "company/repo"},
 }
-var multiRemoteList = []string{"origin	https://username:ghp_pat@github.com/username/repo (fetch)", "origin	https://username:ghp_pat@github.com/username/repo (push)", "upstream	https://username:ghp_pat@github.com/company/repo (fetch)", "upstream	https://username:ghp_pat@github.com/company/repo (push)"}
+var multiRemoteList = []string{"origin	https://github.com/username/repo (fetch)", "origin	https://github.com/username/repo (push)", "upstream	https://github.com/company/repo (fetch)", "upstream	https://github.com/company/repo (push)"}
 
 // Test data for SSH URLs
 var sshRemoteMap = map[string][]string{
@@ -35,6 +42,11 @@ func TestGetRemoteMap(t *testing.T) {
 			"remote URLs with PATs",
 			remotesPATList,
 			remotesPATMap,
+		},
+		{
+			"multiple remote URLs with PATs",
+			multiRemotePATList,
+			multiRemotePATMap,
 		},
 		{
 			"multiple remote URLs",

--- a/utils/fetch_remote_test.go
+++ b/utils/fetch_remote_test.go
@@ -1,0 +1,61 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+var testRemotes = "origin	https://username:ghp_pat@github.com/username/repo\norigin	https://username:ghp_pat@github.com/username/repo"
+
+var testRemoteURL = "https://github.com/username/repo"
+
+func TestShellRemotes(t *testing.T) {
+	if os.Getenv("GO_TEST_PROCESS") != "1" {
+		return
+	}
+	fmt.Fprintln(os.Stdout, testRemotes)
+	os.Exit(0)
+}
+
+func TestShellRemoteURL(t *testing.T) {
+	if os.Getenv("GO_TEST_PROCESS") != "1" {
+		return
+	}
+	fmt.Fprint(os.Stdout, testRemoteURL)
+	os.Exit(0)
+}
+
+// returns a mock command for getting git remotes
+func mockRemotes(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestShellRemotes", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_TEST_PROCESS=1"}
+	return cmd
+}
+
+// returns a mock command for getting git remote URL
+func mockRemoteURL(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestShellRemoteURL", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_TEST_PROCESS=1"}
+	return cmd
+}
+
+func TestListRemotes(t *testing.T) {
+	remoteMap, err := ListRemotes(mockRemotes, mockRemoteURL)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	got := remoteMap["origin"][0]
+	expected := "username"
+
+	if got != expected {
+		t.Errorf("got: %s; expected: %s\n", got, expected)
+	}
+}

--- a/utils/remote_resolver.go
+++ b/utils/remote_resolver.go
@@ -28,7 +28,7 @@ func ResolveRemote(repoArg string) (*RemoteData, error) {
 
 	// If the user didn't pass --repo flag
 	// Figure out list of remotes by reading git config
-	remotesData, err := ListRemotes()
+	remotesData, err := ListRemotes(nil, nil)
 	if err != nil {
 		if strings.Contains(err.Error(), "exit status 128") {
 			fmt.Println("This repository has not been initialized with git. Please initialize it with git using `git init`")

--- a/utils/remote_resolver.go
+++ b/utils/remote_resolver.go
@@ -28,7 +28,7 @@ func ResolveRemote(repoArg string) (*RemoteData, error) {
 
 	// If the user didn't pass --repo flag
 	// Figure out list of remotes by reading git config
-	remotesData, err := ListRemotes(nil, nil)
+	remotesData, err := ListRemotes()
 	if err != nil {
 		if strings.Contains(err.Error(), "exit status 128") {
 			fmt.Println("This repository has not been initialized with git. Please initialize it with git using `git init`")


### PR DESCRIPTION
The current method of extracting owners from remote URLs doesn't work with remote URLs having a PAT in it, for example:

`https://username:<access_token>@github.com/username/repo`

This can be improved by using a regular expression like [this](https://regex101.com/r/xcIeR2/1), which can extract owner names from both type of remote URLs, as shown [here](https://regex101.com/r/xcIeR2/1).

Signed-off-by: burntcarrot <aadhav.n1@gmail.com>