### PR TITLE
tests(config): add tests for config

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var cfg = CLIConfig{
+	Host:                  "deepsource.io",
+	User:                  "test",
+	Token:                 "test_token",
+	RefreshToken:          "test_refresh_token",
+	TokenExpiresIn:        time.Time{},
+	RefreshTokenExpiresIn: time.Time{},
+}
+
+func TestSetTokenExpiry(t *testing.T) {
+	t.Run("must reset with invalid timestamp", func(t *testing.T) {
+		str := "invalid"
+		cfg.SetTokenExpiry(str)
+		want := "0001-01-01 00:00:00 +0000 UTC"
+
+		assert.Equal(t, cfg.TokenExpiresIn.UTC().String(), want)
+	})
+
+	t.Run("must work with valid timestamp", func(t *testing.T) {
+		str := "2021-01-01T00:00:00.999999999"
+		cfg.SetTokenExpiry(str)
+		want := "2021-01-01 00:00:00 +0000 UTC"
+
+		assert.Equal(t, cfg.TokenExpiresIn.UTC().String(), want)
+	})
+}
+
+func TestIsExpired(t *testing.T) {
+	str := time.Now().UTC().Format("2006-01-02T15:04:05.999999999")
+	cfg.SetTokenExpiry(str)
+	result := cfg.IsExpired()
+	assert.Equal(t, true, result)
+}
+
+func TestConfigDir(t *testing.T) {
+	_, err := cfg.configDir()
+	assert.Nil(t, err)
+}
+
+func TestConfigPath(t *testing.T) {
+	_, err := cfg.configPath()
+	assert.Nil(t, err)
+}
+
+func TestGetConfig(t *testing.T) {
+	_, err := GetConfig()
+	assert.Nil(t, err)
+}
+
+func TestVerifyAuthentication(t *testing.T) {
+	t.Run("must return nil when token is provided", func(t *testing.T) {
+		err := cfg.VerifyAuthentication()
+		assert.Nil(t, err)
+	})
+
+	t.Run("must not return nil when empty token is provided", func(t *testing.T) {
+		// set empty token
+		cfg.Token = ""
+		err := cfg.VerifyAuthentication()
+		assert.NotNil(t, err)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.7.1
+	github.com/stretchr/testify v1.7.0
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/crypto v0.0.0-20211202192323-5770296d904e // indirect
 	golang.org/x/sys v0.0.0-20211205182925-97ca703d548d // indirect


### PR DESCRIPTION
Closes #120.

Add tests for `config` package.

Signed-off-by: burntcarrot <aadhav.n1@gmail.com>