### PR TITLE
feat(*): use heredoc for adding CLI documentation

### DIFF
--- a/command/auth/login/login.go
+++ b/command/auth/login/login.go
@@ -6,7 +6,6 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/deepsourcelabs/cli/config"
 	"github.com/deepsourcelabs/cli/utils"
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -25,8 +24,6 @@ type LoginOptions struct {
 // NewCmdLogin handles the login functionality for the CLI
 func NewCmdLogin() *cobra.Command {
 
-	c := color.New(color.FgCyan, color.Bold)
-	y := color.New(color.FgYellow, color.Bold)
 	doc := heredoc.Docf(`
 		Log in to DeepSource using the CLI.
 
@@ -38,7 +35,7 @@ func NewCmdLogin() *cobra.Command {
 
 		Use %[3]s to authenticate with a specific DeepSource instance, for example:
 		%[4]s
-		`, y.Sprintf("--with-token"), c.Sprintf("deepsource auth login --with-token dsp_abcd"), y.Sprintf("--hostname"), c.Sprintf("deepsource auth login --hostname my_instance"))
+		`, utils.Yellow("--with-token"), utils.Cyan("deepsource auth login --with-token dsp_abcd"), utils.Yellow("--hostname"), utils.Cyan("deepsource auth login --hostname my_instance"))
 
 	opts := LoginOptions{
 		AuthTimedOut: false,

--- a/command/auth/login/login.go
+++ b/command/auth/login/login.go
@@ -3,8 +3,10 @@ package login
 import (
 	"fmt"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/deepsourcelabs/cli/config"
 	"github.com/deepsourcelabs/cli/utils"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -23,6 +25,21 @@ type LoginOptions struct {
 // NewCmdLogin handles the login functionality for the CLI
 func NewCmdLogin() *cobra.Command {
 
+	c := color.New(color.FgCyan, color.Bold)
+	y := color.New(color.FgYellow, color.Bold)
+	doc := heredoc.Docf(`
+		Log in to DeepSource using the CLI.
+
+		The default authentication mode is a browser-based login flow.
+		After completion, an authentication token will be stored internally.
+
+		Use %[1]s to pass in a token on standard input, for example:
+		%[2]s
+
+		Use %[3]s to authenticate with a specific DeepSource instance, for example:
+		%[4]s
+		`, y.Sprintf("--with-token"), c.Sprintf("deepsource auth login --with-token dsp_abcd"), y.Sprintf("--hostname"), c.Sprintf("deepsource auth login --hostname my_instance"))
+
 	opts := LoginOptions{
 		AuthTimedOut: false,
 		TokenExpired: true,
@@ -32,7 +49,8 @@ func NewCmdLogin() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "login",
-		Short: "Login to DeepSource using Command Line Interface",
+		Short: "Log in to DeepSource using Command Line Interface",
+		Long:  doc,
 		Args:  utils.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Run()

--- a/command/auth/refresh/refresh.go
+++ b/command/auth/refresh/refresh.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/deepsourcelabs/cli/config"
 	"github.com/deepsourcelabs/cli/deepsource"
 	"github.com/deepsourcelabs/cli/utils"
+	"github.com/fatih/color"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
@@ -17,12 +19,23 @@ type RefreshOptions struct{}
 
 // NewCmdRefresh handles the refreshing of authentication credentials
 func NewCmdRefresh() *cobra.Command {
+
+	c := color.New(color.FgCyan, color.Bold)
+	doc := heredoc.Docf(`
+		Refresh stored authentication credentials.
+
+		Authentication credentials expire after a certain amount of time.
+
+		To renew the authentication credentials, use %[1]s
+		`, c.Sprintf("deepsource auth refresh"))
+
 	opts := RefreshOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "refresh",
 		Short: "Refresh stored authentication credentials",
-		Args:  utils.NoArgs,
+		Long: doc,
+		Args: utils.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Run()
 		},

--- a/command/auth/refresh/refresh.go
+++ b/command/auth/refresh/refresh.go
@@ -10,7 +10,6 @@ import (
 	"github.com/deepsourcelabs/cli/config"
 	"github.com/deepsourcelabs/cli/deepsource"
 	"github.com/deepsourcelabs/cli/utils"
-	"github.com/fatih/color"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
@@ -20,22 +19,21 @@ type RefreshOptions struct{}
 // NewCmdRefresh handles the refreshing of authentication credentials
 func NewCmdRefresh() *cobra.Command {
 
-	c := color.New(color.FgCyan, color.Bold)
 	doc := heredoc.Docf(`
 		Refresh stored authentication credentials.
 
 		Authentication credentials expire after a certain amount of time.
 
 		To renew the authentication credentials, use %[1]s
-		`, c.Sprintf("deepsource auth refresh"))
+		`, utils.Yellow("deepsource auth refresh"))
 
 	opts := RefreshOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "refresh",
 		Short: "Refresh stored authentication credentials",
-		Long: doc,
-		Args: utils.NoArgs,
+		Long:  doc,
+		Args:  utils.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Run()
 		},

--- a/command/auth/status/status.go
+++ b/command/auth/status/status.go
@@ -7,7 +7,6 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/deepsourcelabs/cli/config"
 	"github.com/deepsourcelabs/cli/utils"
-	"github.com/fatih/color"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
@@ -16,12 +15,11 @@ type AuthStatusOptions struct{}
 
 // NewCmdStatus handles the fetching of authentication status of CLI
 func NewCmdStatus() *cobra.Command {
-	c := color.New(color.FgCyan, color.Bold)
 	doc := heredoc.Docf(`
 		View the authentication status.
 
 		To check the authentication status, use %[1]s
-	`, c.Sprintf("deepsource auth status"))
+	`, utils.Cyan("deepsource auth status"))
 
 	cmd := &cobra.Command{
 		Use:   "status",

--- a/command/auth/status/status.go
+++ b/command/auth/status/status.go
@@ -4,8 +4,10 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/deepsourcelabs/cli/config"
 	"github.com/deepsourcelabs/cli/utils"
+	"github.com/fatih/color"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
@@ -14,10 +16,17 @@ type AuthStatusOptions struct{}
 
 // NewCmdStatus handles the fetching of authentication status of CLI
 func NewCmdStatus() *cobra.Command {
+	c := color.New(color.FgCyan, color.Bold)
+	doc := heredoc.Docf(`
+		View the authentication status.
+
+		To check the authentication status, use %[1]s
+	`, c.Sprintf("deepsource auth status"))
 
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "View the authentication status",
+		Long:  doc,
 		Args:  utils.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts := AuthStatusOptions{}

--- a/command/config/generate/generate.go
+++ b/command/config/generate/generate.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/deepsourcelabs/cli/config"
 	"github.com/deepsourcelabs/cli/utils"
 	"github.com/fatih/color"
@@ -27,9 +28,18 @@ type Options struct {
 func NewCmdConfigGenerate() *cobra.Command {
 	o := Options{}
 
+	home, _ := os.UserHomeDir()
+	c := color.New(color.FgCyan, color.Bold)
+	doc := heredoc.Docf(`
+		Generate config for the DeepSource CLI.
+
+		Configs are stored in: %[1]s
+		`, c.Sprintf(filepath.Join(home, "deepsource", "config.toml")))
+
 	cmd := &cobra.Command{
 		Use:   "generate",
 		Short: "Generate config for DeepSource",
+		Long:  doc,
 		Args:  utils.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run()

--- a/command/config/generate/generate.go
+++ b/command/config/generate/generate.go
@@ -29,12 +29,11 @@ func NewCmdConfigGenerate() *cobra.Command {
 	o := Options{}
 
 	home, _ := os.UserHomeDir()
-	c := color.New(color.FgCyan, color.Bold)
 	doc := heredoc.Docf(`
 		Generate config for the DeepSource CLI.
 
 		Configs are stored in: %[1]s
-		`, c.Sprintf(filepath.Join(home, "deepsource", "config.toml")))
+		`, utils.Cyan(filepath.Join(home, "deepsource", "config.toml")))
 
 	cmd := &cobra.Command{
 		Use:   "generate",

--- a/command/issues/list/list.go
+++ b/command/issues/list/list.go
@@ -13,7 +13,6 @@ import (
 	"github.com/deepsourcelabs/cli/deepsource"
 	"github.com/deepsourcelabs/cli/deepsource/issues"
 	"github.com/deepsourcelabs/cli/utils"
-	"github.com/fatih/color"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
@@ -41,8 +40,6 @@ func NewCmdIssuesList() *cobra.Command {
 		LimitArg: 30,
 	}
 
-	c := color.New(color.FgCyan, color.Bold)
-	y := color.New(color.FgYellow, color.Bold)
 	doc := heredoc.Docf(`
 		List issues reported by DeepSource.
 
@@ -69,7 +66,7 @@ func NewCmdIssuesList() *cobra.Command {
 
 		To export listed issues to a SARIF file, use the %[14]s flag:
 		%[15]s
-		`, c.Sprintf("deepsource issues list"), y.Sprintf("--repo"), c.Sprintf("deepsource issues list --repo repo_name"), y.Sprintf("--analyzer"), c.Sprintf("deepsource issues list --analyzer python"), y.Sprintf("--limit"), c.Sprintf("deepsource issues list --limit 100"), y.Sprintf("--output-file"), c.Sprintf("deepsource issues list --output-file file_name"), y.Sprintf("--json"), c.Sprintf("deepsource issues list --json --output-file example.json"), y.Sprintf("--csv"), c.Sprintf("deepsource issues list --csv --output-file example.csv"), y.Sprintf("--sarif"), c.Sprintf("deepsource issues list --sarif --output-file example.sarif"))
+		`, utils.Cyan("deepsource issues list"), utils.Yellow("--repo"), utils.Cyan("deepsource issues list --repo repo_name"), utils.Yellow("--analyzer"), utils.Cyan("deepsource issues list --analyzer python"), utils.Yellow("--limit"), utils.Cyan("deepsource issues list --limit 100"), utils.Yellow("--output-file"), utils.Cyan("deepsource issues list --output-file file_name"), utils.Yellow("--json"), utils.Cyan("deepsource issues list --json --output-file example.json"), utils.Yellow("--csv"), utils.Cyan("deepsource issues list --csv --output-file example.csv"), utils.Yellow("--sarif"), utils.Cyan("deepsource issues list --sarif --output-file example.sarif"))
 
 	cmd := &cobra.Command{
 		Use:   "list",

--- a/command/issues/list/list.go
+++ b/command/issues/list/list.go
@@ -8,10 +8,12 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/deepsourcelabs/cli/config"
 	"github.com/deepsourcelabs/cli/deepsource"
 	"github.com/deepsourcelabs/cli/deepsource/issues"
 	"github.com/deepsourcelabs/cli/utils"
+	"github.com/fatih/color"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
@@ -39,9 +41,40 @@ func NewCmdIssuesList() *cobra.Command {
 		LimitArg: 30,
 	}
 
+	c := color.New(color.FgCyan, color.Bold)
+	y := color.New(color.FgYellow, color.Bold)
+	doc := heredoc.Docf(`
+		List issues reported by DeepSource.
+
+		To list issues for the current repository:
+		%[1]s
+
+		To list issues for a specific repository, use the %[2]s flag:
+		%[3]s
+
+		To list issues for a specific analyzer, use the %[4]s flag:
+		%[5]s
+
+		To limit the number of issues reported, use the %[6]s flag:
+		%[7]s
+
+		To export listed issues to a file, use the %[8]s flag:
+		%[9]s
+
+		To export listed issues to a JSON file, use the %[10]s flag:
+		%[11]s
+
+		To export listed issues to a CSV file, use the %[12]s flag:
+		%[13]s
+
+		To export listed issues to a SARIF file, use the %[14]s flag:
+		%[15]s
+		`, c.Sprintf("deepsource issues list"), y.Sprintf("--repo"), c.Sprintf("deepsource issues list --repo repo_name"), y.Sprintf("--analyzer"), c.Sprintf("deepsource issues list --analyzer python"), y.Sprintf("--limit"), c.Sprintf("deepsource issues list --limit 100"), y.Sprintf("--output-file"), c.Sprintf("deepsource issues list --output-file file_name"), y.Sprintf("--json"), c.Sprintf("deepsource issues list --json --output-file example.json"), y.Sprintf("--csv"), c.Sprintf("deepsource issues list --csv --output-file example.csv"), y.Sprintf("--sarif"), c.Sprintf("deepsource issues list --sarif --output-file example.sarif"))
+
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List issues reported by DeepSource",
+		Long:  doc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.FileArg = args
 			return opts.Run()

--- a/command/repo/status/status.go
+++ b/command/repo/status/status.go
@@ -8,7 +8,6 @@ import (
 	"github.com/deepsourcelabs/cli/config"
 	"github.com/deepsourcelabs/cli/deepsource"
 	"github.com/deepsourcelabs/cli/utils"
-	"github.com/fatih/color"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
@@ -27,8 +26,6 @@ func NewCmdRepoStatus() *cobra.Command {
 		TokenExpired: config.Cfg.IsExpired(),
 	}
 
-	c := color.New(color.FgCyan, color.Bold)
-	y := color.New(color.FgYellow, color.Bold)
 	doc := heredoc.Docf(`
 		View the activation status for the repository.
 
@@ -37,7 +34,7 @@ func NewCmdRepoStatus() *cobra.Command {
 
 		To check if a specific repository is activated on DeepSource, use the %[2]s flag:
 		%[3]s
-		`, c.Sprintf("deepsource repo status"), y.Sprintf("--repo"), c.Sprintf("deepsource repo status --repo repo_name"))
+		`, utils.Cyan("deepsource repo status"), utils.Yellow("--repo"), utils.Cyan("deepsource repo status --repo repo_name"))
 
 	cmd := &cobra.Command{
 		Use:   "status",

--- a/command/repo/status/status.go
+++ b/command/repo/status/status.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/deepsourcelabs/cli/config"
 	"github.com/deepsourcelabs/cli/deepsource"
 	"github.com/deepsourcelabs/cli/utils"
+	"github.com/fatih/color"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
@@ -25,9 +27,22 @@ func NewCmdRepoStatus() *cobra.Command {
 		TokenExpired: config.Cfg.IsExpired(),
 	}
 
+	c := color.New(color.FgCyan, color.Bold)
+	y := color.New(color.FgYellow, color.Bold)
+	doc := heredoc.Docf(`
+		View the activation status for the repository.
+
+		To check if the current repository is activated on DeepSource, run:
+		%[1]s
+
+		To check if a specific repository is activated on DeepSource, use the %[2]s flag:
+		%[3]s
+		`, c.Sprintf("deepsource repo status"), y.Sprintf("--repo"), c.Sprintf("deepsource repo status --repo repo_name"))
+
 	cmd := &cobra.Command{
 		Use:   "status",
-		Short: "Refresh stored authentication credentials",
+		Short: "View the activation status for the repository.",
+		Long:  doc,
 		Args:  utils.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Run()

--- a/command/repo/view/view.go
+++ b/command/repo/view/view.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/browser"
 	"github.com/deepsourcelabs/cli/config"
 	"github.com/deepsourcelabs/cli/deepsource"
 	"github.com/deepsourcelabs/cli/utils"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -32,9 +34,17 @@ func NewCmdRepoView() *cobra.Command {
 		SelectedRemote: &utils.RemoteData{},
 	}
 
+	c := color.New(color.FgCyan, color.Bold)
+	doc := heredoc.Docf(`
+		Open the DeepSource dashboard of a repository.
+
+		Run %[1]s to open the DeepSource dashboard inside the browser.
+		`, c.Sprintf("deepsource repo view"))
+
 	cmd := &cobra.Command{
 		Use:   "view",
 		Short: "Open the DeepSource dashboard of a repository",
+		Long:  doc,
 		Args:  utils.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Run()

--- a/command/repo/view/view.go
+++ b/command/repo/view/view.go
@@ -11,7 +11,6 @@ import (
 	"github.com/deepsourcelabs/cli/config"
 	"github.com/deepsourcelabs/cli/deepsource"
 	"github.com/deepsourcelabs/cli/utils"
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -34,12 +33,11 @@ func NewCmdRepoView() *cobra.Command {
 		SelectedRemote: &utils.RemoteData{},
 	}
 
-	c := color.New(color.FgCyan, color.Bold)
 	doc := heredoc.Docf(`
 		Open the DeepSource dashboard of a repository.
 
 		Run %[1]s to open the DeepSource dashboard inside the browser.
-		`, c.Sprintf("deepsource repo view"))
+		`, utils.Cyan("deepsource repo view"))
 
 	cmd := &cobra.Command{
 		Use:   "view",

--- a/command/report/report.go
+++ b/command/report/report.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/deepsourcelabs/cli/utils"
-	"github.com/fatih/color"
 	"github.com/getsentry/sentry-go"
 	"github.com/spf13/cobra"
 )
@@ -27,8 +26,6 @@ type ReportOptions struct {
 func NewCmdReport() *cobra.Command {
 	opts := ReportOptions{}
 
-	c := color.New(color.FgCyan, color.Bold)
-	y := color.New(color.FgYellow, color.Bold)
 	doc := heredoc.Docf(`
 		Report artifacts to DeepSource.
 
@@ -40,7 +37,7 @@ func NewCmdReport() *cobra.Command {
 
 		You can flag combinations as well:
 		%[5]s
-		`, y.Sprintf("--analyzer"), c.Sprintf("deepsource report --analyzer python"), y.Sprintf("--value"), c.Sprintf("deepsource report --key value"), c.Sprintf("deepsource report --analyzer go --value-file coverage.out"))
+		`, utils.Yellow("--analyzer"), utils.Cyan("deepsource report --analyzer python"), utils.Yellow("--value"), utils.Cyan("deepsource report --key value"), utils.Cyan("deepsource report --analyzer go --value-file coverage.out"))
 
 	cmd := &cobra.Command{
 		Use:   "report",

--- a/command/report/report.go
+++ b/command/report/report.go
@@ -37,7 +37,10 @@ func NewCmdReport() *cobra.Command {
 
 		Use %[3]s to specify the value of the artifact:
 		%[4]s
-		`, y.Sprintf("--analyzer"), c.Sprintf("deepsource report --analyzer python"), y.Sprintf("--value"), c.Sprintf("deepsource report --key value"))
+
+		You can flag combinations as well:
+		%[5]s
+		`, y.Sprintf("--analyzer"), c.Sprintf("deepsource report --analyzer python"), y.Sprintf("--value"), c.Sprintf("deepsource report --key value"), c.Sprintf("deepsource report --analyzer go --value-file coverage.out"))
 
 	cmd := &cobra.Command{
 		Use:   "report",

--- a/command/report/report.go
+++ b/command/report/report.go
@@ -9,7 +9,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/deepsourcelabs/cli/utils"
+	"github.com/fatih/color"
 	"github.com/getsentry/sentry-go"
 	"github.com/spf13/cobra"
 )
@@ -25,9 +27,22 @@ type ReportOptions struct {
 func NewCmdReport() *cobra.Command {
 	opts := ReportOptions{}
 
+	c := color.New(color.FgCyan, color.Bold)
+	y := color.New(color.FgYellow, color.Bold)
+	doc := heredoc.Docf(`
+		Report artifacts to DeepSource.
+
+		Use %[1]s to specify the analyzer, for example:
+		%[2]s
+
+		Use %[3]s to specify the value of the artifact:
+		%[4]s
+		`, y.Sprintf("--analyzer"), c.Sprintf("deepsource report --analyzer python"), y.Sprintf("--value"), c.Sprintf("deepsource report --key value"))
+
 	cmd := &cobra.Command{
 		Use:   "report",
 		Short: "Report artifacts to DeepSource",
+		Long:  doc,
 		Args:  utils.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			returnCode := opts.Run()

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.12
 	github.com/Jeffail/gabs/v2 v2.6.1
+	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/cli/browser v1.1.0
 	github.com/deepsourcelabs/graphql v0.2.2
 	github.com/fatih/color v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/Jeffail/gabs/v2 v2.6.1 h1:wwbE6nTQTwIMsMxzi6XFQQYRZ6wDc1mSdxoAN+9U4Gk
 github.com/Jeffail/gabs/v2 v2.6.1/go.mod h1:xCn81vdHKxFUuWWAaD5jCTQDNPBMh5pPs9IJ+NcziBI=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/Joker/jade v1.0.1-0.20190614124447-d475f43051e7/go.mod h1:6E6s8o2AE4KhCrqr6GRJjdC/gNfTdxkIXvuGZZda2VM=
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8 h1:xzYJEypr/85nBpB11F9br+3HUrpgb+fcm5iADzXXYEw=
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8/go.mod h1:oX5x61PbNXchhh0oikYAH+4Pcfw5LKv21+Jnpr6r6Pc=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/utils/colors.go
+++ b/utils/colors.go
@@ -4,10 +4,10 @@ import "github.com/fatih/color"
 
 func Yellow(format string, a ...interface{}) string {
 	c := color.New(color.FgYellow, color.Bold)
-	return c.Sprintf(format, a)
+	return c.Sprintf(format, a...)
 }
 
 func Cyan(format string, a ...interface{}) string {
 	c := color.New(color.FgCyan, color.Bold)
-	return c.Sprintf(format, a)
+	return c.Sprintf(format, a...)
 }

--- a/utils/colors.go
+++ b/utils/colors.go
@@ -1,0 +1,13 @@
+package utils
+
+import "github.com/fatih/color"
+
+func Yellow(format string, a ...interface{}) string {
+	c := color.New(color.FgYellow, color.Bold)
+	return c.Sprintf(format, a)
+}
+
+func Cyan(format string, a ...interface{}) string {
+	c := color.New(color.FgCyan, color.Bold)
+	return c.Sprintf(format, a)
+}


### PR DESCRIPTION
Closes: #121

Adds `heredoc` for CLI documentation.

Signed-off-by: burntcarrot <aadhav.n1@gmail.com>