### PR TITLE
tests(utils): add tests for remote resolver

### DIFF
--- a/utils/remote_resolver_test.go
+++ b/utils/remote_resolver_test.go
@@ -1,0 +1,58 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveRemote(t *testing.T) {
+	tests := []struct {
+		name    string
+		repoArg string
+		want    *RemoteData
+		wantErr bool
+	}{
+		{
+			name:    "valid github remote URL",
+			repoArg: "github.com/deepsourcelabs/cli",
+			want:    &RemoteData{Owner: "deepsourcelabs", RepoName: "cli", VCSProvider: "GITHUB"},
+			wantErr: false,
+		},
+		{
+			name:    "valid gitlab remote URL",
+			repoArg: "gitlab.com/deepsourcelabs/cli",
+			want:    &RemoteData{Owner: "deepsourcelabs", RepoName: "cli", VCSProvider: "GITLAB"},
+			wantErr: false,
+		},
+		{
+			name:    "valid bitbucket remote URL",
+			repoArg: "bitbucket.com/deepsourcelabs/cli",
+			want:    &RemoteData{Owner: "deepsourcelabs", RepoName: "cli", VCSProvider: "BITBUCKET"},
+			wantErr: false,
+		},
+		{
+			name:    "invalid VCS provider",
+			repoArg: "example.com/deepsourcelabs/cli",
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveRemote(tt.repoArg)
+
+			if tt.wantErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got: %v, want: %v\n", got, tt.want)
+			}
+		})
+	}
+}

--- a/utils/remote_resolver_test.go
+++ b/utils/remote_resolver_test.go
@@ -21,14 +21,32 @@ func TestResolveRemote(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "valid github remote URL (short form)",
+			repoArg: "gh/deepsourcelabs/cli",
+			want:    &RemoteData{Owner: "deepsourcelabs", RepoName: "cli", VCSProvider: "GITHUB"},
+			wantErr: false,
+		},
+		{
 			name:    "valid gitlab remote URL",
 			repoArg: "gitlab.com/deepsourcelabs/cli",
 			want:    &RemoteData{Owner: "deepsourcelabs", RepoName: "cli", VCSProvider: "GITLAB"},
 			wantErr: false,
 		},
 		{
+			name:    "valid gitlab remote URL (short form)",
+			repoArg: "gl/deepsourcelabs/cli",
+			want:    &RemoteData{Owner: "deepsourcelabs", RepoName: "cli", VCSProvider: "GITLAB"},
+			wantErr: false,
+		},
+		{
 			name:    "valid bitbucket remote URL",
 			repoArg: "bitbucket.com/deepsourcelabs/cli",
+			want:    &RemoteData{Owner: "deepsourcelabs", RepoName: "cli", VCSProvider: "BITBUCKET"},
+			wantErr: false,
+		},
+		{
+			name:    "valid bitbucket remote URL (short form)",
+			repoArg: "bb/deepsourcelabs/cli",
 			want:    &RemoteData{Owner: "deepsourcelabs", RepoName: "cli", VCSProvider: "BITBUCKET"},
 			wantErr: false,
 		},


### PR DESCRIPTION
Closes: #122.

Adds tests for `remote_resolver` utility.