### PR TITLE
feat(backend/docker): add --image-name flag for running analyzers

### DIFF
--- a/analyzers/backend/docker/build.go
+++ b/analyzers/backend/docker/build.go
@@ -49,17 +49,6 @@ func (d *DockerClient) SetupClient() error {
 	return nil
 }
 
-// PullImage pulls an image from a registry.
-func (d *DockerClient) PullImage(imageName string) error {
-	ctx := context.Background()
-	_, err := d.Client.ImagePull(ctx, imageName, types.ImagePullOptions{})
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // BuildAnalyzerDockerImage is the docker image build API used by various CLI commands
 func (d *DockerClient) BuildAnalyzerDockerImage() (context.CancelFunc, io.ReadCloser, *DockerBuildError) {
 	var err error

--- a/analyzers/backend/docker/build.go
+++ b/analyzers/backend/docker/build.go
@@ -38,15 +38,31 @@ func (d *DockerBuildError) Error() string {
 	return d.Message
 }
 
-// BuildAnalyzerDockerImage is the docker image build API used by various CLI commands
-func (d *DockerClient) BuildAnalyzerDockerImage() (context.CancelFunc, io.ReadCloser, *DockerBuildError) {
+// SetupClient initializes the Docker client with opts.
+func (d *DockerClient) SetupClient() error {
 	var err error
 	d.Client, err = client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
-		return nil, nil, &DockerBuildError{
-			Message: err.Error(),
-		}
+		return err
 	}
+
+	return nil
+}
+
+// PullImage pulls an image from a registry.
+func (d *DockerClient) PullImage(imageName string) error {
+	ctx := context.Background()
+	_, err := d.Client.ImagePull(ctx, imageName, types.ImagePullOptions{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// BuildAnalyzerDockerImage is the docker image build API used by various CLI commands
+func (d *DockerClient) BuildAnalyzerDockerImage() (context.CancelFunc, io.ReadCloser, *DockerBuildError) {
+	var err error
 
 	cancelFunc, responseReader, err := d.executeImageBuild()
 	if err != nil {

--- a/analyzers/backend/docker/pull.go
+++ b/analyzers/backend/docker/pull.go
@@ -11,11 +11,11 @@ import (
 func (d *DockerClient) PullImage(imageName string) (context.CancelFunc, io.ReadCloser, error) {
 	ctx, ctxCancelFunc := context.WithTimeout(context.Background(), buildTimeout)
 
-	readCloser, err := d.Client.ImagePull(ctx, imageName, types.ImagePullOptions{})
+	reader, err := d.Client.ImagePull(ctx, imageName, types.ImagePullOptions{})
 	if err != nil {
 		ctxCancelFunc()
 		return ctxCancelFunc, nil, err
 	}
 
-	return ctxCancelFunc, readCloser, nil
+	return ctxCancelFunc, reader, nil
 }

--- a/analyzers/backend/docker/pull.go
+++ b/analyzers/backend/docker/pull.go
@@ -1,0 +1,21 @@
+package docker
+
+import (
+	"context"
+	"io"
+
+	"github.com/docker/docker/api/types"
+)
+
+// PullImage pulls an image from a registry.
+func (d *DockerClient) PullImage(imageName string) (context.CancelFunc, io.ReadCloser, error) {
+	ctx, ctxCancelFunc := context.WithTimeout(context.Background(), buildTimeout)
+
+	readCloser, err := d.Client.ImagePull(ctx, imageName, types.ImagePullOptions{})
+	if err != nil {
+		ctxCancelFunc()
+		return ctxCancelFunc, nil, err
+	}
+
+	return ctxCancelFunc, readCloser, nil
+}

--- a/command/analyzer/dryrun/run.go
+++ b/command/analyzer/dryrun/run.go
@@ -124,6 +124,12 @@ func (a *AnalyzerDryRun) AnalyzerRun() (err error) {
 		// Setup image name and image tag. The image name and image tag are used while building the container.
 		a.Client.ImageName, a.Client.ImageTag = a.parseImageName()
 
+		// Notify the user that we use the latest tag.
+		// TODO: Setting the suffix doesn't work.
+		if a.Client.ImageTag == "latest" {
+			a.Spinner.SetSuffix("(no image tag found, using latest)")
+		}
+
 		a.Spinner.StopSpinner()
 	} else {
 		// Building the Analyzer image.

--- a/command/analyzer/dryrun/run.go
+++ b/command/analyzer/dryrun/run.go
@@ -32,6 +32,7 @@ var (
 // The params required while running the Analysis locally.
 type AnalyzerDryRun struct {
 	Client               *docker.DockerClient   // The client to be used for all docker related ops.
+	DockerImageName      string                 // The name of the Docker image published to a registry.
 	DockerImagePlatform  string                 // The platform for which the Docker image is to be built.
 	RemoteSource         bool                   // True if the source to be analyzed is a remote VCS repository.
 	SourcePath           string                 // The path of the directory of source code to be analyzed.
@@ -73,6 +74,9 @@ func NewCmdAnalyzerRun() *cobra.Command {
 	// --output-file/ -o flag.
 	cmd.Flags().StringVarP(&opts.TempToolBoxDirectory, "output-file", "o", "", "The path of analysis results")
 
+	// --image-name flag.
+	cmd.Flags().StringVar(&opts.DockerImageName, "image-name", "", "The name of the Docker image")
+
 	// --platform flag; used for explicitly setting up the build platform for the Docker image. Defaults to linux/<arch> if not provided.
 	defaultPlatform := fmt.Sprintf("linux/%s", runtime.GOARCH)
 	cmd.Flags().StringVar(&opts.DockerImagePlatform, "platform", defaultPlatform, "Explicitly set build platform for Docker image.")
@@ -87,26 +91,46 @@ func (a *AnalyzerDryRun) AnalyzerRun() (err error) {
 		return err
 	}
 
-	// Building the Analyzer image.
-	a.Spinner.StartSpinnerWithLabel("Building Analyzer image...", "Built Analyzer image")
-	ctxCancelFunc, buildRespReader, buildError := a.Client.BuildAnalyzerDockerImage()
-
-	// Cancel the build context and close the reader before exiting this function.
-	if buildRespReader != nil {
-		defer buildRespReader.Close()
-	}
-	defer ctxCancelFunc()
-	if buildError != nil {
-		a.Spinner.StopSpinnerWithError("Failed to build the Analyzer image", err)
-		return buildError
-	}
-
-	// Check the docker build response.
-	if err = docker.CheckBuildResponse(buildRespReader, false); err != nil {
-		a.Spinner.StopSpinnerWithError("Failed to build the Analyzer image", err)
+	err = a.Client.SetupClient()
+	if err != nil {
 		return err
 	}
-	a.Spinner.StopSpinner()
+
+	if a.DockerImageName != "" {
+		a.Spinner.StartSpinnerWithLabel("Fetching Analyzer image...", "Fetched analyzer image")
+
+		// Pull image from registry.
+		err := a.Client.PullImage(a.DockerImageName)
+		if err != nil {
+			return err
+		}
+
+		// Setup image name and image tag. The image name and image tag are used while building the container.
+		a.Client.ImageName, a.Client.ImageTag = a.parseImageName()
+
+		a.Spinner.StopSpinner()
+	} else {
+		// Building the Analyzer image.
+		a.Spinner.StartSpinnerWithLabel("Building Analyzer image...", "Built Analyzer image")
+		ctxCancelFunc, buildRespReader, buildError := a.Client.BuildAnalyzerDockerImage()
+
+		// Cancel the build context and close the reader before exiting this function.
+		if buildRespReader != nil {
+			defer buildRespReader.Close()
+		}
+		defer ctxCancelFunc()
+		if buildError != nil {
+			a.Spinner.StopSpinnerWithError("Failed to build the Analyzer image", err)
+			return buildError
+		}
+
+		// Check the docker build response.
+		if err = docker.CheckBuildResponse(buildRespReader, false); err != nil {
+			a.Spinner.StopSpinnerWithError("Failed to build the Analyzer image", err)
+			return err
+		}
+		a.Spinner.StopSpinner()
+	}
 
 	// Create temporary toolbox directory to store analysis config and later analyis results.
 	// If already passed through --output-file flag, use that one.

--- a/command/analyzer/dryrun/utils.go
+++ b/command/analyzer/dryrun/utils.go
@@ -83,3 +83,14 @@ func (a *AnalyzerDryRun) createTemporaryToolBoxDir() (err error) {
 	a.Client.AnalysisOpts.AnalysisResultsPath = a.TempToolBoxDirectory
 	return nil
 }
+
+// parseImageName returns the image name and the image tag from the complete image name.
+func (a *AnalyzerDryRun) parseImageName() (string, string) {
+	components := strings.Split(a.DockerImageName, ":")
+
+	if len(components) > 1 {
+		return components[0], components[1]
+	} else {
+		return components[0], "latest"
+	}
+}

--- a/command/analyzer/verify/build.go
+++ b/command/analyzer/verify/build.go
@@ -53,6 +53,12 @@ func (a *AnalyzerVerifyOpts) verifyAnalyzerDockerBuild() (err error) {
 		ShowLogs:       a.Build.VerboseMode,
 	}
 
+	// Setup client for the builder.
+	err = analyzerBuilder.SetupClient()
+	if err != nil {
+		return err
+	}
+
 	// Build the docker image :rocket:
 	ctxCancelFunc, buildRespReader, buildErr := analyzerBuilder.BuildAnalyzerDockerImage()
 

--- a/utils/spinner.go
+++ b/utils/spinner.go
@@ -25,6 +25,7 @@ func (s *SpinnerUtils) StartSpinnerWithLabel(label, finalMessage string) {
 		spinner.WithWriter(os.Stdout),
 		spinner.WithWriter(os.Stderr),
 	) // Build our new spinner
+
 	if label != "" {
 		sp.Suffix = " " + label + " "
 	}
@@ -47,7 +48,7 @@ func (s *SpinnerUtils) StopSpinner() {
 	s.Spinner = nil
 }
 
-// Stops the spinner
+// Sets a suffix to the spinner.
 func (s *SpinnerUtils) SetSuffix(suffix string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
Adds a `--image-name` flag for running analyzers.

Example usage:

```sh
deepsource analyzer dry-run --image-name burntcarrot/2do-checker:latest
```

Screencast: https://asciinema.org/a/HzbEWDOm6W7h0ImKSyQW9yLQy