### PR TITLE
feat: provide Homebrew completions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ dist
 coverage.out
 cover.out
 
+# Completion files
+completions

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -1,4 +1,9 @@
 project_name: deepsource
+
+before:
+  hooks:
+    - ../../scripts/gen-completions.sh
+
 builds:
   -
     env:
@@ -57,4 +62,9 @@ brews:
     homepage: "https://github.com/deepsourcelabs/cli"
     description: "Command line interface to DeepSource"
     license: "BSD 2-Clause Simplified License"
+    install: |
+      bin.install "deepsource"
+      bash_completion.install "completions/deepsource.bash" => "deepsource"
+      zsh_completion.install "completions/deepsource.zsh" => "_deepsource"
+      fish_completion.install "completions/deepsource.fish"
     skip_upload: auto

--- a/scripts/gen-completions.sh
+++ b/scripts/gen-completions.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+rm -rf completions
+mkdir completions
+
+for shell in bash zsh fish; do
+  go run main.go completion "$shell" > "completions/deepsource.$shell"
+done

--- a/scripts/gen-completions.sh
+++ b/scripts/gen-completions.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
 set -e
-
 rm -rf completions
 mkdir completions
 
+# Generate completion using the in-built cobra completion command
 for shell in bash zsh fish; do
   go run main.go completion "$shell" > "completions/deepsource.$shell"
 done


### PR DESCRIPTION
This adds a hook for `goreleaser` which will install the completions using `cobra` and Homebrew will pick them up when installing.