### PR TITLE
feat: add DeepSource TCV reporter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,35 +1,28 @@
 name: goreleaser
-
 on:
   push:
     tags:
       - '*'
-
 permissions:
   contents: write
-
 jobs:
   release-cli:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: master
+        uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser
           version: latest
-          workdir: ./cmd/deepsource
-          args: release --rm-dist --config ../../goreleaser.yaml
+          args: release --rm-dist --config goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TOKEN: ${{ secrets.DS_BOT_PAT }}

--- a/cmd/deepsource_tcv/main.go
+++ b/cmd/deepsource_tcv/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"log"
+	"os"
+	"time"
+
+	commandtcv "github.com/deepsourcelabs/cli/command_tcv"
+	v "github.com/deepsourcelabs/cli/version"
+	"github.com/getsentry/sentry-go"
+	"github.com/pterm/pterm"
+)
+
+var (
+	// Version is the build version.  This is set using ldflags -X
+	version = "development"
+
+	// Date is the build date.  This is set using ldflags -X
+	Date = "YYYY-MM-DD" // YYYY-MM-DD
+
+	// DSN used for sentry
+	SentryDSN string
+)
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+
+	// Init sentry
+	err := sentry.Init(sentry.ClientOptions{
+		Dsn: SentryDSN,
+	})
+	if err != nil {
+		log.Println("Could not load sentry.")
+	}
+	v.SetBuildInfo(version, Date, "", "")
+
+	// Setup command
+	command := commandtcv.NewCmdTCV()
+
+	if err := command.Execute(); err != nil {
+		// TODO: Handle exit codes here
+		pterm.Error.Println(err)
+		sentry.CaptureException(err)
+		sentry.Flush(2 * time.Second)
+		os.Exit(1)
+	}
+}

--- a/command_tcv/root.go
+++ b/command_tcv/root.go
@@ -1,0 +1,23 @@
+package commandtcv
+
+import (
+	"github.com/deepsourcelabs/cli/command/report"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdTCV returns a Cobra command containing commands related to test coverage reporting.
+func NewCmdTCV() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "deepsource <command> <subcommand> [flags]",
+		Short: "DeepSource CLI",
+		Long: `Welcome to DeepSource CLI
+Now ship good code directly from the command line.
+Login into DeepSource using the command : deepsource auth login`,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+
+	cmd.AddCommand(report.NewCmdReport())
+
+	return cmd
+}

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -1,6 +1,7 @@
 project_name: deepsource
 builds:
-  -
+  - id: "tcv-deepsource"
+    main: ./cmd/deepsource_tcv/main.go
     env:
       - CGO_ENABLED=0
     flags:
@@ -8,7 +9,40 @@ builds:
     goos:
       - freebsd
       - openbsd
-      - netbsd
+        # TODO: figure out netbsd builds
+        # - netbsd
+      - linux
+      - darwin
+    goarch:
+      - 386
+      - amd64
+      - arm64
+    ldflags:
+      - "-X 'main.version={{ .Version }}' -X 'main.SentryDSN={{ .Env.DEEPSOURCE_CLI_SENTRY_DSN }}'"
+  - id: "windows-tcv-deepsource"
+    main: ./cmd/deepsource_tcv/main.go
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -tags=static_all
+    goos:
+      - windows
+    goarch:
+      - amd64
+    ldflags:
+      - buildmode=exe
+      - "-X 'main.version={{ .Version }}' -X 'main.SentryDSN={{ .Env.DEEPSOURCE_CLI_SENTRY_DSN }}'"
+  - id: "deepsource"
+    main: ./cmd/deepsource/main.go
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -tags=static_all
+    goos:
+      - freebsd
+      - openbsd
+         # TODO: figure out netbsd builds
+        # - netbsd
       - linux
       - darwin
     goarch:
@@ -18,6 +52,7 @@ builds:
     ldflags:
       - "-X 'main.version={{ .Version }}' -X 'main.SentryDSN={{ .Env.DEEPSOURCE_CLI_SENTRY_DSN }}'"
   - id: "windows-deepsource"
+    main: ./cmd/deepsource/main.go
     env:
       - CGO_ENABLED=0
     flags:
@@ -32,9 +67,29 @@ builds:
 
 archives:
   -
+    id: "deepsource_tcv"
+    builds: ['tcv-deepsource', 'windows-tcv-deepsource']
+    name_template: "{{.ProjectName}}_tcv_{{.Version}}_{{.Os}}_{{.Arch}}"
     replacements:
       386: i386
       amd64: x86_64
+  -
+    id: "deepsource"
+    builds: ['deepsource', 'windows-deepsource']
+    name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}_{{.Arch}}"
+    replacements:
+      386: i386
+      amd64: x86_64
+
+
+
+
+
+
+
+
+    @@ -45,16 +90,16 @@ changelog:
+
 checksum:
   name_template: 'checksums.txt'
 snapshot:
@@ -45,16 +100,17 @@ changelog:
     exclude:
     - '^tests:'
 
-brews:
-  - tap:
-      owner: deepsourcelabs
-      name: homebrew-cli
-      branch: cli-release
-      token: "{{ .Env.HOMEBREW_TOKEN }}"
-    commit_author:
-      name: deepsourcebot
-      email: bot@deepsource.io
-    homepage: "https://github.com/deepsourcelabs/cli"
-    description: "Command line interface to DeepSource"
-    license: "BSD 2-Clause Simplified License"
-    skip_upload: auto
+# TODO: fix homebrew tap (siddhant-deepsource)
+# brews:
+#   - tap:
+#       owner: deepsourcelabs
+#       name: homebrew-cli
+#       branch: cli-release
+#       token: "{{ .Env.HOMEBREW_TOKEN }}"
+#     commit_author:
+#       name: deepsourcebot
+#       email: bot@deepsource.io
+#     homepage: "https://github.com/deepsourcelabs/cli"
+#     description: "Command line interface to DeepSource"
+#     license: "BSD 2-Clause Simplified License"
+#     skip_upload: auto

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -81,15 +81,6 @@ archives:
       386: i386
       amd64: x86_64
 
-
-
-
-
-
-
-
-    @@ -45,16 +90,16 @@ changelog:
-
 checksum:
   name_template: 'checksums.txt'
 snapshot:
@@ -100,17 +91,18 @@ changelog:
     exclude:
     - '^tests:'
 
-# TODO: fix homebrew tap (siddhant-deepsource)
-# brews:
-#   - tap:
-#       owner: deepsourcelabs
-#       name: homebrew-cli
-#       branch: cli-release
-#       token: "{{ .Env.HOMEBREW_TOKEN }}"
-#     commit_author:
-#       name: deepsourcebot
-#       email: bot@deepsource.io
-#     homepage: "https://github.com/deepsourcelabs/cli"
-#     description: "Command line interface to DeepSource"
-#     license: "BSD 2-Clause Simplified License"
-#     skip_upload: auto
+brews:
+  - ids:
+    - deepsource
+  - tap:
+      owner: deepsourcelabs
+      name: homebrew-cli
+      branch: cli-release
+      token: "{{ .Env.HOMEBREW_TOKEN }}"
+    commit_author:
+      name: deepsourcebot
+      email: bot@deepsource.io
+    homepage: "https://github.com/deepsourcelabs/cli"
+    description: "Command line interface to DeepSource"
+    license: "BSD 2-Clause Simplified License"
+    skip_upload: auto

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -73,6 +73,7 @@ archives:
     replacements:
       386: i386
       amd64: x86_64
+      windows: windows
   -
     id: "deepsource"
     builds: ['deepsource', 'windows-deepsource']
@@ -80,6 +81,7 @@ archives:
     replacements:
       386: i386
       amd64: x86_64
+      windows: windows
 
 checksum:
   name_template: 'checksums.txt'

--- a/install.sh
+++ b/install.sh
@@ -1,33 +1,34 @@
 #!/bin/sh
-set -e
 
+set -e
 
 # The install script is licensed under BSD 2-Clause "Simplified" License.
 
 usage() {
-  this=$1
+	this=$1
 
-  cat <<EOF
+	cat <<EOF
 Download DeepSource CLI binary from https://github.com/deepsourcelabs/cli
+
 EOF
-  exit 2
+	exit 2
 }
 
 parse_args() {
-  #BINDIR is ./bin unless set be ENV
-  # over-ridden by flag below
+	#BINDIR is ./bin unless set be ENV
+	# over-ridden by flag below
 
-  BINDIR=${BINDIR:-./bin}
-  while getopts "b:dh?x" arg; do
-    case "$arg" in
-      b) BINDIR="$OPTARG" ;;
-      d) log_set_priority 10 ;;
-      h | \?) usage "$0" ;;
-      x) set -x ;;
-    esac
-  done
-  shift $((OPTIND - 1))
-  TAG=$1
+	BINDIR=${BINDIR:-./bin}
+	while getopts "b:dh?x" arg; do
+		case "$arg" in
+		b) BINDIR="$OPTARG" ;;
+		d) log_set_priority 10 ;;
+		h | \?) usage "$0" ;;
+		x) set -x ;;
+		esac
+	done
+	shift $((OPTIND - 1))
+	TAG=$1
 
 }
 # this function wraps all the destructive operations
@@ -35,86 +36,85 @@ parse_args() {
 # network, either nothing will happen or will syntax error
 # out preventing half-done work
 execute() {
-  tmpdir=$(mktemp -d)
-  log_debug "downloading files into ${tmpdir}"
-  http_download "${tmpdir}/${TARBALL}" "${TARBALL_URL}"
-  http_download "${tmpdir}/${CHECKSUM}" "${CHECKSUM_URL}"
-  hash_sha256_verify "${tmpdir}/${TARBALL}" "${tmpdir}/${CHECKSUM}"
-  srcdir="${tmpdir}"
-  (cd "${tmpdir}" && untar "${TARBALL}")
-  test ! -d "${BINDIR}" && install -d "${BINDIR}"
-  for binexe in $BINARIES; do
-    if [ "$OS" = "windows" ]; then
-      binexe="${binexe}.exe"
-    fi
-    install "${srcdir}/${binexe}" "${BINDIR}/"
-    log_info "installed ${BINDIR}/${binexe}"
-  done
-  rm -rf "${tmpdir}"
+	tmpdir=$(mktemp -d)
+	log_debug "downloading files into ${tmpdir}"
+	http_download "${tmpdir}/${TARBALL}" "${TARBALL_URL}"
+	http_download "${tmpdir}/${CHECKSUM}" "${CHECKSUM_URL}"
+	hash_sha256_verify "${tmpdir}/${TARBALL}" "${tmpdir}/${CHECKSUM}"
+	srcdir="${tmpdir}"
+	(cd "${tmpdir}" && untar "${TARBALL}")
+	test ! -d "${BINDIR}" && install -d "${BINDIR}"
+	for binexe in $BINARIES; do
+		if [ "$OS" = "windows" ]; then
+			binexe="${binexe}.exe"
+		fi
+		install "${srcdir}/${binexe}" "${BINDIR}/"
+		log_info "installed ${BINDIR}/${binexe}"
+	done
+	rm -rf "${tmpdir}"
 }
 get_binaries() {
-  case "$PLATFORM" in
-    darwin/386) BINARIES="deepsource" ;;
-    darwin/amd64) BINARIES="deepsource" ;;
-    darwin/arm64) BINARIES="deepsource" ;;
-    darwin/armv6) BINARIES="deepsource" ;;
-    freebsd/386) BINARIES="deepsource" ;;
-    freebsd/amd64) BINARIES="deepsource" ;;
-    freebsd/arm64) BINARIES="deepsource" ;;
-    freebsd/armv6) BINARIES="deepsource" ;;
-    linux/386) BINARIES="deepsource" ;;
-    linux/amd64) BINARIES="deepsource" ;;
-    linux/arm64) BINARIES="deepsource" ;;
-    linux/armv6) BINARIES="deepsource" ;;
-    netbsd/386) BINARIES="deepsource" ;;
-    netbsd/amd64) BINARIES="deepsource" ;;
-    netbsd/arm64) BINARIES="deepsource" ;;
-    netbsd/armv6) BINARIES="deepsource" ;;
-    openbsd/386) BINARIES="deepsource" ;;
-    openbsd/amd64) BINARIES="deepsource" ;;
-    openbsd/arm64) BINARIES="deepsource" ;;
-    openbsd/armv6) BINARIES="deepsource" ;;
-    windows/amd64) BINARIES="deepsource" ;;
-    *)
-      log_crit "platform $PLATFORM is not supported.  Make sure this script is up-to-date and file request at https://github.com/${PREFIX}/issues/new"
-      exit 1
-      ;;
-  esac
+	case "$PLATFORM" in
+	darwin/386) BINARIES="deepsource" ;;
+	darwin/amd64) BINARIES="deepsource" ;;
+	darwin/arm64) BINARIES="deepsource" ;;
+	darwin/armv6) BINARIES="deepsource" ;;
+	freebsd/386) BINARIES="deepsource" ;;
+	freebsd/amd64) BINARIES="deepsource" ;;
+	freebsd/arm64) BINARIES="deepsource" ;;
+	freebsd/armv6) BINARIES="deepsource" ;;
+	linux/386) BINARIES="deepsource" ;;
+	linux/amd64) BINARIES="deepsource" ;;
+	linux/arm64) BINARIES="deepsource" ;;
+	linux/armv6) BINARIES="deepsource" ;;
+	netbsd/386) BINARIES="deepsource" ;;
+	netbsd/amd64) BINARIES="deepsource" ;;
+	netbsd/arm64) BINARIES="deepsource" ;;
+	netbsd/armv6) BINARIES="deepsource" ;;
+	openbsd/386) BINARIES="deepsource" ;;
+	openbsd/amd64) BINARIES="deepsource" ;;
+	openbsd/arm64) BINARIES="deepsource" ;;
+	openbsd/armv6) BINARIES="deepsource" ;;
+	*)
+		log_crit "platform $PLATFORM is not supported.  Make sure this script is up-to-date and file request at https://github.com/${PREFIX}/issues/new"
+		exit 1
+		;;
+	esac
 }
 tag_to_version() {
-  if [ -z "${TAG}" ]; then
-    log_info "checking GitHub for latest tag"
-  else
-    log_info "checking GitHub for tag '${TAG}'"
-  fi
-  REALTAG=$(github_release "$OWNER/$REPO" "${TAG}") && true
-  if test -z "$REALTAG"; then
-    log_crit "unable to find '${TAG}' - use 'latest' or see https://github.com/${PREFIX}/releases for details"
-    exit 1
-  fi
-  # if version starts with 'v', remove it
-  TAG="$REALTAG"
-  VERSION=${TAG#v}
+	if [ -z "${TAG}" ]; then
+		log_info "checking GitHub for latest tag"
+	else
+		log_info "checking GitHub for tag '${TAG}'"
+	fi
+	REALTAG=$(github_release "$OWNER/$REPO" "${TAG}") && true
+	if test -z "$REALTAG"; then
+		log_crit "unable to find '${TAG}' - use 'latest' or see https://github.com/${PREFIX}/releases for details"
+		exit 1
+	fi
+	# if version starts with 'v', remove it
+	TAG="$REALTAG"
+	VERSION=${TAG#v}
 }
 adjust_format() {
-  # change format (tar.gz or zip) based on OS
-  true
+	# change format (tar.gz or zip) based on OS
+	true
 }
 adjust_os() {
-  # adjust archive name based on OS
-  case ${OS} in
-    386) OS=i386 ;;
-    amd64) OS=x86_64 ;;
-  esac
-  true
+	# adjust archive name based on OS
+	case ${OS} in
+	386) OS=i386 ;;
+	amd64) OS=x86_64 ;;
+	esac
+	true
 }
 adjust_arch() {
-  # adjust archive name based on ARCH
-  case ${ARCH} in
-    386) ARCH=i386 ;;
-    amd64) ARCH=x86_64 ;;
-  esac
-  true
+	# adjust archive name based on ARCH
+	case ${ARCH} in
+	386) ARCH=i386 ;;
+	amd64) ARCH=x86_64 ;;
+	esac
+	true
 }
 
 cat /dev/null <<EOF
@@ -126,246 +126,246 @@ but credit (and pull requests) appreciated.
 ------------------------------------------------------------------------
 EOF
 is_command() {
-  command -v "$1" >/dev/null
+	command -v "$1" >/dev/null
 }
 echoerr() {
-  echo "$@" 1>&2
+	echo "$@" 1>&2
 }
 log_prefix() {
-  echo "$0"
+	echo "$0"
 }
 _logp=6
 log_set_priority() {
-  _logp="$1"
+	_logp="$1"
 }
 log_priority() {
-  if test -z "$1"; then
-    echo "$_logp"
-    return
-  fi
-  [ "$1" -le "$_logp" ]
+	if test -z "$1"; then
+		echo "$_logp"
+		return
+	fi
+	[ "$1" -le "$_logp" ]
 }
 log_tag() {
-  case $1 in
-    0) echo "emerg" ;;
-    1) echo "alert" ;;
-    2) echo "crit" ;;
-    3) echo "err" ;;
-    4) echo "warning" ;;
-    5) echo "notice" ;;
-    6) echo "info" ;;
-    7) echo "debug" ;;
-    *) echo "$1" ;;
-  esac
+	case $1 in
+	0) echo "emerg" ;;
+	1) echo "alert" ;;
+	2) echo "crit" ;;
+	3) echo "err" ;;
+	4) echo "warning" ;;
+	5) echo "notice" ;;
+	6) echo "info" ;;
+	7) echo "debug" ;;
+	*) echo "$1" ;;
+	esac
 }
 log_debug() {
-  log_priority 7 || return 0
-  echoerr "$(log_prefix)" "$(log_tag 7)" "$@"
+	log_priority 7 || return 0
+	echoerr "$(log_prefix)" "$(log_tag 7)" "$@"
 }
 
 log_info() {
-  log_priority 6 || return 0
-  echoerr "$(log_prefix)" "$(log_tag 6)" "$@"
+	log_priority 6 || return 0
+	echoerr "$(log_prefix)" "$(log_tag 6)" "$@"
 }
 log_err() {
-  log_priority 3 || return 0
-  echoerr "$(log_prefix)" "$(log_tag 3)" "$@"
+	log_priority 3 || return 0
+	echoerr "$(log_prefix)" "$(log_tag 3)" "$@"
 }
 log_crit() {
-  log_priority 2 || return 0
+	log_priority 2 || return 0
 
-  echoerr "$(log_prefix)" "$(log_tag 2)" "$@"
+	echoerr "$(log_prefix)" "$(log_tag 2)" "$@"
 
 }
 uname_os() {
 
-  os=$(uname -s | tr '[:upper:]' '[:lower:]')
+	os=$(uname -s | tr '[:upper:]' '[:lower:]')
 
-  case "$os" in
-    cygwin_nt*) os="windows" ;;
-    mingw*) os="windows" ;;
-    msys_nt*) os="windows" ;;
-  esac
-  echo "$os"
+	case "$os" in
+	cygwin_nt*) os="windows" ;;
+	mingw*) os="windows" ;;
+	msys_nt*) os="windows" ;;
+	esac
+	echo "$os"
 }
 uname_arch() {
 
-  arch=$(uname -m)
+	arch=$(uname -m)
 
-  case $arch in
-    x86_64) arch="amd64" ;;
-    x86) arch="386" ;;
-    i686) arch="386" ;;
-    i386) arch="386" ;;
-    aarch64) arch="arm64" ;;
-    armv5*) arch="armv5" ;;
-    armv6*) arch="armv6" ;;
-    armv7*) arch="armv7" ;;
-  esac
-  echo ${arch}
+	case $arch in
+	x86_64) arch="amd64" ;;
+	x86) arch="386" ;;
+	i686) arch="386" ;;
+	i386) arch="386" ;;
+	aarch64) arch="arm64" ;;
+	armv5*) arch="armv5" ;;
+	armv6*) arch="armv6" ;;
+	armv7*) arch="armv7" ;;
+	esac
+	echo ${arch}
 }
 uname_os_check() {
-  os=$(uname_os)
-  case "$os" in
-    darwin) return 0 ;;
-    dragonfly) return 0 ;;
-    freebsd) return 0 ;;
+	os=$(uname_os)
+	case "$os" in
+	darwin) return 0 ;;
+	dragonfly) return 0 ;;
+	freebsd) return 0 ;;
 
-    linux) return 0 ;;
-    android) return 0 ;;
-    nacl) return 0 ;;
-    netbsd) return 0 ;;
-    openbsd) return 0 ;;
-    plan9) return 0 ;;
+	linux) return 0 ;;
+	android) return 0 ;;
+	nacl) return 0 ;;
+	netbsd) return 0 ;;
+	openbsd) return 0 ;;
+	plan9) return 0 ;;
 
-    solaris) return 0 ;;
-    windows) return 0 ;;
+	solaris) return 0 ;;
+	windows) return 0 ;;
 
-  esac
-  log_crit "uname_os_check '$(uname -s)' got converted to '$os' which is not a GOOS value. Please file bug at https://github.com/client9/shlib"
-  return 1
+	esac
+	log_crit "uname_os_check '$(uname -s)' got converted to '$os' which is not a GOOS value. Please file bug at https://github.com/client9/shlib"
+	return 1
 }
 uname_arch_check() {
 
-  arch=$(uname_arch)
-  case "$arch" in
-    386) return 0 ;;
-    amd64) return 0 ;;
-    arm64) return 0 ;;
-    armv5) return 0 ;;
+	arch=$(uname_arch)
+	case "$arch" in
+	386) return 0 ;;
+	amd64) return 0 ;;
+	arm64) return 0 ;;
+	armv5) return 0 ;;
 
-    armv6) return 0 ;;
-    armv7) return 0 ;;
-    ppc64) return 0 ;;
-    ppc64le) return 0 ;;
-    mips) return 0 ;;
-    mipsle) return 0 ;;
-    mips64) return 0 ;;
-    mips64le) return 0 ;;
-    s390x) return 0 ;;
+	armv6) return 0 ;;
+	armv7) return 0 ;;
+	ppc64) return 0 ;;
+	ppc64le) return 0 ;;
+	mips) return 0 ;;
+	mipsle) return 0 ;;
+	mips64) return 0 ;;
+	mips64le) return 0 ;;
+	s390x) return 0 ;;
 
-    amd64p32) return 0 ;;
-  esac
-  log_crit "uname_arch_check '$(uname -m)' got converted to '$arch' which is not a GOARCH value.  Please file bug report at https://github.com/client9/shlib"
-  return 1
+	amd64p32) return 0 ;;
+	esac
+	log_crit "uname_arch_check '$(uname -m)' got converted to '$arch' which is not a GOARCH value.  Please file bug report at https://github.com/client9/shlib"
+	return 1
 }
 untar() {
 
-  tarball=$1
+	tarball=$1
 
-  case "${tarball}" in
-    *.tar.gz | *.tgz) tar --no-same-owner -xzf "${tarball}" ;;
+	case "${tarball}" in
+	*.tar.gz | *.tgz) tar --no-same-owner -xzf "${tarball}" ;;
 
-    *.tar) tar --no-same-owner -xf "${tarball}" ;;
-    *.zip) unzip "${tarball}" ;;
-    *)
-      log_err "untar unknown archive format for ${tarball}"
-      return 1
-      ;;
-  esac
+	*.tar) tar --no-same-owner -xf "${tarball}" ;;
+	*.zip) unzip "${tarball}" ;;
+	*)
+		log_err "untar unknown archive format for ${tarball}"
+		return 1
+		;;
+	esac
 }
 http_download_curl() {
-  local_file=$1
-  source_url=$2
-  header=$3
-  if [ -z "$header" ]; then
-    code=$(curl -w '%{http_code}' -sL -o "$local_file" "$source_url")
-  else
-    code=$(curl -w '%{http_code}' -sL -H "$header" -o "$local_file" "$source_url")
-  fi
-  if [ "$code" != "200" ]; then
-    log_debug "http_download_curl received HTTP status $code"
+	local_file=$1
+	source_url=$2
+	header=$3
+	if [ -z "$header" ]; then
+		code=$(curl -w '%{http_code}' -sL -o "$local_file" "$source_url")
+	else
+		code=$(curl -w '%{http_code}' -sL -H "$header" -o "$local_file" "$source_url")
+	fi
+	if [ "$code" != "200" ]; then
+		log_debug "http_download_curl received HTTP status $code"
 
-    return 1
-  fi
-  return 0
+		return 1
+	fi
+	return 0
 }
 
 http_download_wget() {
-  local_file=$1
-  source_url=$2
-  header=$3
-  if [ -z "$header" ]; then
-    wget -q -O "$local_file" "$source_url"
-  else
-    wget -q --header "$header" -O "$local_file" "$source_url"
-  fi
+	local_file=$1
+	source_url=$2
+	header=$3
+	if [ -z "$header" ]; then
+		wget -q -O "$local_file" "$source_url"
+	else
+		wget -q --header "$header" -O "$local_file" "$source_url"
+	fi
 
 }
 http_download() {
-  log_debug "http_download $2"
-  if is_command curl; then
-    http_download_curl "$@"
-    return
-  elif is_command wget; then
-    http_download_wget "$@"
-    return
-  fi
-  log_crit "http_download unable to find wget or curl"
-  return 1
+	log_debug "http_download $2"
+	if is_command curl; then
+		http_download_curl "$@"
+		return
+	elif is_command wget; then
+		http_download_wget "$@"
+		return
+	fi
+	log_crit "http_download unable to find wget or curl"
+	return 1
 }
 http_copy() {
-  tmp=$(mktemp)
-  http_download "${tmp}" "$1" "$2" || return 1
-  body=$(cat "$tmp")
-  rm -f "${tmp}"
-  echo "$body"
+	tmp=$(mktemp)
+	http_download "${tmp}" "$1" "$2" || return 1
+	body=$(cat "$tmp")
+	rm -f "${tmp}"
+	echo "$body"
 }
 github_release() {
 
-  owner_repo=$1
-  version=$2
-  test -z "$version" && version="latest"
-  giturl="https://github.com/${owner_repo}/releases/${version}"
-  json=$(http_copy "$giturl" "Accept:application/json")
-  test -z "$json" && return 1
-  version=$(echo "$json" | tr -s '\n' ' ' | sed 's/.*"tag_name":"//' | sed 's/".*//')
-  test -z "$version" && return 1
-  echo "$version"
+	owner_repo=$1
+	version=$2
+	test -z "$version" && version="latest"
+	giturl="https://github.com/${owner_repo}/releases/${version}"
+	json=$(http_copy "$giturl" "Accept:application/json")
+	test -z "$json" && return 1
+	version=$(echo "$json" | tr -s '\n' ' ' | sed 's/.*"tag_name":"//' | sed 's/".*//')
+	test -z "$version" && return 1
+	echo "$version"
 }
 hash_sha256() {
-  TARGET=${1:-/dev/stdin}
-  if is_command gsha256sum; then
-    hash=$(gsha256sum "$TARGET") || return 1
-    echo "$hash" | cut -d ' ' -f 1
-  elif is_command sha256sum; then
-    hash=$(sha256sum "$TARGET") || return 1
-    echo "$hash" | cut -d ' ' -f 1
-  elif is_command shasum; then
-    hash=$(shasum -a 256 "$TARGET" 2>/dev/null) || return 1
+	TARGET=${1:-/dev/stdin}
+	if is_command gsha256sum; then
+		hash=$(gsha256sum "$TARGET") || return 1
+		echo "$hash" | cut -d ' ' -f 1
+	elif is_command sha256sum; then
+		hash=$(sha256sum "$TARGET") || return 1
+		echo "$hash" | cut -d ' ' -f 1
+	elif is_command shasum; then
+		hash=$(shasum -a 256 "$TARGET" 2>/dev/null) || return 1
 
-    echo "$hash" | cut -d ' ' -f 1
-  elif is_command openssl; then
-    hash=$(openssl -dst openssl dgst -sha256 "$TARGET") || return 1
+		echo "$hash" | cut -d ' ' -f 1
+	elif is_command openssl; then
+		hash=$(openssl -dst openssl dgst -sha256 "$TARGET") || return 1
 
-    echo "$hash" | cut -d ' ' -f a
-  else
-    log_crit "hash_sha256 unable to find command to compute sha-256 hash"
-    return 1
-  fi
+		echo "$hash" | cut -d ' ' -f a
+	else
+		log_crit "hash_sha256 unable to find command to compute sha-256 hash"
+		return 1
+	fi
 
 }
 hash_sha256_verify() {
-  TARGET=$1
+	TARGET=$1
 
-  checksums=$2
-  if [ -z "$checksums" ]; then
-    log_err "hash_sha256_verify checksum file not specified in arg2"
-    return 1
-  fi
+	checksums=$2
+	if [ -z "$checksums" ]; then
+		log_err "hash_sha256_verify checksum file not specified in arg2"
+		return 1
+	fi
 
-  BASENAME=${TARGET##*/}
-  want=$(grep "${BASENAME}" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
-  if [ -z "$want" ]; then
+	BASENAME=${TARGET##*/}
+	want=$(grep "${BASENAME}" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
+	if [ -z "$want" ]; then
 
-    log_err "hash_sha256_verify unable to find checksum for '${TARGET}' in '${checksums}'"
-    return 1
-  fi
-  got=$(hash_sha256 "$TARGET")
-  if [ "$want" != "$got" ]; then
-    log_err "hash_sha256_verify checksum for '$TARGET' did not verify ${want} vs $got"
-    return 1
-  fi
+		log_err "hash_sha256_verify unable to find checksum for '${TARGET}' in '${checksums}'"
+		return 1
+	fi
+	got=$(hash_sha256 "$TARGET")
+	if [ "$want" != "$got" ]; then
+		log_err "hash_sha256_verify checksum for '$TARGET' did not verify ${want} vs $got"
+		return 1
+	fi
 }
 
 cat /dev/null <<EOF
@@ -373,7 +373,6 @@ cat /dev/null <<EOF
 End of functions from https://github.com/client9/shlib
 ------------------------------------------------------------------------
 EOF
-
 
 PROJECT_NAME="deepsource"
 OWNER=deepsourcelabs
@@ -384,7 +383,6 @@ OS=$(uname_os)
 ARCH=$(uname_arch)
 PREFIX="$OWNER/$REPO"
 
-
 # use in logging routines
 
 log_prefix() {
@@ -393,7 +391,6 @@ log_prefix() {
 }
 PLATFORM="${OS}/${ARCH}"
 GITHUB_DOWNLOAD=https://github.com/${OWNER}/${REPO}/releases/download
-
 
 uname_os_check "$OS"
 uname_arch_check "$ARCH"
@@ -404,7 +401,6 @@ get_binaries
 
 tag_to_version
 
-
 adjust_format
 
 adjust_os
@@ -413,36 +409,36 @@ adjust_arch
 
 log_info "found version: ${VERSION} for ${TAG}/${OS}/${ARCH}"
 
-# check for these environment variables (CI)
-# https://github.com/watson/ci-info/blob/master/vendors.json
-ci_vars="APPVEYOR SYSTEM_TEAMFOUNDATIONCOLLECTIONURI AC_APPCIRCLE bamboo_planKey BITBUCKET_COMMIT BITRISE_IO BUDDY_WORKSPACE_ID BUILDKITE CI CIRCLECI CIRRUS_CI CODEBUILD_BUILD_ARN CF_BUILD_ID CI_NAME DRONE DSARI EAS_BUILD GITHUB_ACTIONS GITLAB_CI GO_PIPELINE_LABEL LAYERCI HUDSON_URL JENKINS_URL MAGNUM NETLIFY NEVERCODE RENDER SAILCI SEMAPHORE SCREWDRIVER SHIPPABLE TDDIUM STRIDER TEAMCITY_VERSION TRAVIS NOW_BUILDER APPCENTER_BUILD_ID"
-
 # check_vars checks environment variables and determines the version of the CLI to be pulled.
-check_vars()
-{
-    ci_vars_count=0
-    for var_name in $ci_vars; do
-        if [ -n "${!var_name}" ]; then
-          log_info "$var_name has the value: ${!var_name}"
-          ((ci_vars_count=ci_vars_count+1))
-        fi
-    done
+check_vars() {
+	ci_vars_count=0
+	var_names="$@"
+	for var_name in $var_names; do
+		newvar="$(eval "echo $var_name")"
+		env_var_value="$(eval "echo \${$newvar}")"
+		if [ "$env_var_value" != "" ]; then
+			log_info "$var_name has the value: ${env_var_value}"
+			ci_vars_count=$(($ci_vars_count + 1))
+		fi
+	done
 
-    # only display logs if env vars are found.
-    if [[ "$ci_vars_count" -gt 0 ]]; then
-    log_info "Found ${ci_vars_count} env vars related to CI."
-    fi
+	# only display logs if env vars are found.
+	if [ "$ci_vars_count" -gt 0 ]; then
+		log_info "Found ${ci_vars_count} env vars related to CI."
+	fi
 
-    # if there are 1 or more env vars, use the deepsource_tcv version
-    if [[ "$ci_vars_count" -gt 0 ]]; then
-      NAME=${PROJECT_NAME}_tcv_${VERSION}_${OS}_${ARCH}
-      log_info "CI server detected. Pulling lightweight version of the CLI."
-    else
-      NAME=${PROJECT_NAME}_${VERSION}_${OS}_${ARCH}
-    fi
+	# if there are 1 or more env vars, use the deepsource_tcv version
+	if [ "$ci_vars_count" -gt 0 ]; then
+		NAME=${PROJECT_NAME}_tcv_${VERSION}_${OS}_${ARCH}
+		log_info "CI server detected. Pulling lightweight version of the CLI."
+	else
+		NAME=${PROJECT_NAME}_${VERSION}_${OS}_${ARCH}
+	fi
 }
 
-check_vars
+# check for these environment variables (CI)
+# https://github.com/watson/ci-info/blob/master/vendors.json
+check_vars APPVEYOR SYSTEM_TEAMFOUNDATIONCOLLECTIONURI AC_APPCIRCLE bamboo_planKey BITBUCKET_COMMIT BITRISE_IO BUDDY_WORKSPACE_ID BUILDKITE CI CIRCLECI CIRRUS_CI CODEBUILD_BUILD_ARN CF_BUILD_ID CI_NAME DRONE DSARI EAS_BUILD GITHUB_ACTIONS GITLAB_CI GO_PIPELINE_LABEL LAYERCI HUDSON_URL JENKINS_URL MAGNUM NETLIFY NEVERCODE RENDER SAILCI SEMAPHORE SCREWDRIVER SHIPPABLE TDDIUM STRIDER TEAMCITY_VERSION TRAVIS NOW_BUILDER APPCENTER_BUILD_ID
 
 TARBALL=${NAME}.${FORMAT}
 

--- a/install.sh
+++ b/install.sh
@@ -75,6 +75,7 @@ get_binaries() {
 	openbsd/amd64) BINARIES="deepsource" ;;
 	openbsd/arm64) BINARIES="deepsource" ;;
 	openbsd/armv6) BINARIES="deepsource" ;;
+	windows/amd64) BINARIES="deepsource" ;;
 	*)
 		log_crit "platform $PLATFORM is not supported.  Make sure this script is up-to-date and file request at https://github.com/${PREFIX}/issues/new"
 		exit 1

--- a/install.sh
+++ b/install.sh
@@ -74,6 +74,7 @@ get_binaries() {
     openbsd/amd64) BINARIES="deepsource" ;;
     openbsd/arm64) BINARIES="deepsource" ;;
     openbsd/armv6) BINARIES="deepsource" ;;
+    windows/amd64) BINARIES="deepsource" ;;
     *)
       log_crit "platform $PLATFORM is not supported.  Make sure this script is up-to-date and file request at https://github.com/${PREFIX}/issues/new"
       exit 1

--- a/install.sh
+++ b/install.sh
@@ -412,13 +412,16 @@ adjust_arch
 
 log_info "found version: ${VERSION} for ${TAG}/${OS}/${ARCH}"
 
+# check for these environment variables (CI)
+# https://github.com/watson/ci-info/blob/master/vendors.json
+ci_vars="APPVEYOR SYSTEM_TEAMFOUNDATIONCOLLECTIONURI AC_APPCIRCLE bamboo_planKey BITBUCKET_COMMIT BITRISE_IO BUDDY_WORKSPACE_ID BUILDKITE CI CIRCLECI CIRRUS_CI CODEBUILD_BUILD_ARN CF_BUILD_ID CI_NAME DRONE DSARI EAS_BUILD GITHUB_ACTIONS GITLAB_CI GO_PIPELINE_LABEL LAYERCI HUDSON_URL JENKINS_URL MAGNUM NETLIFY NEVERCODE RENDER SAILCI SEMAPHORE SCREWDRIVER SHIPPABLE TDDIUM STRIDER TEAMCITY_VERSION TRAVIS NOW_BUILDER APPCENTER_BUILD_ID"
+
 # check_vars checks environment variables and determines the version of the CLI to be pulled.
 check_vars()
 {
     ci_vars_count=0
-    var_names=("$@")
-    for var_name in "${var_names[@]}"; do
-        if [ ! -z "${!var_name}" ]; then
+    for var_name in $ci_vars; do
+        if [ -n "${!var_name}" ]; then
           log_info "$var_name has the value: ${!var_name}"
           ((ci_vars_count=ci_vars_count+1))
         fi
@@ -438,9 +441,7 @@ check_vars()
     fi
 }
 
-# check for these environment variables (CI)
-# https://github.com/watson/ci-info/blob/master/vendors.json
-check_vars APPVEYOR SYSTEM_TEAMFOUNDATIONCOLLECTIONURI AC_APPCIRCLE bamboo_planKey BITBUCKET_COMMIT BITRISE_IO BUDDY_WORKSPACE_ID BUILDKITE CI CIRCLECI CIRRUS_CI CODEBUILD_BUILD_ARN CF_BUILD_ID CI_NAME DRONE DSARI EAS_BUILD GITHUB_ACTIONS GITLAB_CI GO_PIPELINE_LABEL LAYERCI HUDSON_URL JENKINS_URL MAGNUM NETLIFY NEVERCODE RENDER SAILCI SEMAPHORE SCREWDRIVER SHIPPABLE TDDIUM STRIDER TEAMCITY_VERSION TRAVIS NOW_BUILDER APPCENTER_BUILD_ID
+check_vars
 
 TARBALL=${NAME}.${FORMAT}
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,452 @@
+#!/bin/sh
+set -e
+
+
+# The install script is licensed under BSD 2-Clause "Simplified" License.
+
+usage() {
+  this=$1
+
+  cat <<EOF
+Download DeepSource CLI binary from https://github.com/deepsourcelabs/cli
+EOF
+  exit 2
+}
+
+parse_args() {
+  #BINDIR is ./bin unless set be ENV
+  # over-ridden by flag below
+
+  BINDIR=${BINDIR:-./bin}
+  while getopts "b:dh?x" arg; do
+    case "$arg" in
+      b) BINDIR="$OPTARG" ;;
+      d) log_set_priority 10 ;;
+      h | \?) usage "$0" ;;
+      x) set -x ;;
+    esac
+  done
+  shift $((OPTIND - 1))
+  TAG=$1
+
+}
+# this function wraps all the destructive operations
+# if a curl|bash cuts off the end of the script due to
+# network, either nothing will happen or will syntax error
+# out preventing half-done work
+execute() {
+  tmpdir=$(mktemp -d)
+  log_debug "downloading files into ${tmpdir}"
+  http_download "${tmpdir}/${TARBALL}" "${TARBALL_URL}"
+  http_download "${tmpdir}/${CHECKSUM}" "${CHECKSUM_URL}"
+  hash_sha256_verify "${tmpdir}/${TARBALL}" "${tmpdir}/${CHECKSUM}"
+  srcdir="${tmpdir}"
+  (cd "${tmpdir}" && untar "${TARBALL}")
+  test ! -d "${BINDIR}" && install -d "${BINDIR}"
+  for binexe in $BINARIES; do
+    if [ "$OS" = "windows" ]; then
+      binexe="${binexe}.exe"
+    fi
+    install "${srcdir}/${binexe}" "${BINDIR}/"
+    log_info "installed ${BINDIR}/${binexe}"
+  done
+  rm -rf "${tmpdir}"
+}
+get_binaries() {
+  case "$PLATFORM" in
+    darwin/386) BINARIES="deepsource" ;;
+    darwin/amd64) BINARIES="deepsource" ;;
+    darwin/arm64) BINARIES="deepsource" ;;
+    darwin/armv6) BINARIES="deepsource" ;;
+    freebsd/386) BINARIES="deepsource" ;;
+    freebsd/amd64) BINARIES="deepsource" ;;
+    freebsd/arm64) BINARIES="deepsource" ;;
+    freebsd/armv6) BINARIES="deepsource" ;;
+    linux/386) BINARIES="deepsource" ;;
+    linux/amd64) BINARIES="deepsource" ;;
+    linux/arm64) BINARIES="deepsource" ;;
+    linux/armv6) BINARIES="deepsource" ;;
+    netbsd/386) BINARIES="deepsource" ;;
+    netbsd/amd64) BINARIES="deepsource" ;;
+    netbsd/arm64) BINARIES="deepsource" ;;
+    netbsd/armv6) BINARIES="deepsource" ;;
+    openbsd/386) BINARIES="deepsource" ;;
+    openbsd/amd64) BINARIES="deepsource" ;;
+    openbsd/arm64) BINARIES="deepsource" ;;
+    openbsd/armv6) BINARIES="deepsource" ;;
+    *)
+      log_crit "platform $PLATFORM is not supported.  Make sure this script is up-to-date and file request at https://github.com/${PREFIX}/issues/new"
+      exit 1
+      ;;
+  esac
+}
+tag_to_version() {
+  if [ -z "${TAG}" ]; then
+    log_info "checking GitHub for latest tag"
+  else
+    log_info "checking GitHub for tag '${TAG}'"
+  fi
+  REALTAG=$(github_release "$OWNER/$REPO" "${TAG}") && true
+  if test -z "$REALTAG"; then
+    log_crit "unable to find '${TAG}' - use 'latest' or see https://github.com/${PREFIX}/releases for details"
+    exit 1
+  fi
+  # if version starts with 'v', remove it
+  TAG="$REALTAG"
+  VERSION=${TAG#v}
+}
+adjust_format() {
+  # change format (tar.gz or zip) based on OS
+  true
+}
+adjust_os() {
+  # adjust archive name based on OS
+  case ${OS} in
+    386) OS=i386 ;;
+    amd64) OS=x86_64 ;;
+  esac
+  true
+}
+adjust_arch() {
+  # adjust archive name based on ARCH
+  case ${ARCH} in
+    386) ARCH=i386 ;;
+    amd64) ARCH=x86_64 ;;
+  esac
+  true
+}
+
+cat /dev/null <<EOF
+------------------------------------------------------------------------
+https://github.com/client9/shlib - portable posix shell functions
+Public domain - http://unlicense.org
+https://github.com/client9/shlib/blob/master/LICENSE.md
+but credit (and pull requests) appreciated.
+------------------------------------------------------------------------
+EOF
+is_command() {
+  command -v "$1" >/dev/null
+}
+echoerr() {
+  echo "$@" 1>&2
+}
+log_prefix() {
+  echo "$0"
+}
+_logp=6
+log_set_priority() {
+  _logp="$1"
+}
+log_priority() {
+  if test -z "$1"; then
+    echo "$_logp"
+    return
+  fi
+  [ "$1" -le "$_logp" ]
+}
+log_tag() {
+  case $1 in
+    0) echo "emerg" ;;
+    1) echo "alert" ;;
+    2) echo "crit" ;;
+    3) echo "err" ;;
+    4) echo "warning" ;;
+    5) echo "notice" ;;
+    6) echo "info" ;;
+    7) echo "debug" ;;
+    *) echo "$1" ;;
+  esac
+}
+log_debug() {
+  log_priority 7 || return 0
+  echoerr "$(log_prefix)" "$(log_tag 7)" "$@"
+}
+
+log_info() {
+  log_priority 6 || return 0
+  echoerr "$(log_prefix)" "$(log_tag 6)" "$@"
+}
+log_err() {
+  log_priority 3 || return 0
+  echoerr "$(log_prefix)" "$(log_tag 3)" "$@"
+}
+log_crit() {
+  log_priority 2 || return 0
+
+  echoerr "$(log_prefix)" "$(log_tag 2)" "$@"
+
+}
+uname_os() {
+
+  os=$(uname -s | tr '[:upper:]' '[:lower:]')
+
+  case "$os" in
+    cygwin_nt*) os="windows" ;;
+    mingw*) os="windows" ;;
+    msys_nt*) os="windows" ;;
+  esac
+  echo "$os"
+}
+uname_arch() {
+
+  arch=$(uname -m)
+
+  case $arch in
+    x86_64) arch="amd64" ;;
+    x86) arch="386" ;;
+    i686) arch="386" ;;
+    i386) arch="386" ;;
+    aarch64) arch="arm64" ;;
+    armv5*) arch="armv5" ;;
+    armv6*) arch="armv6" ;;
+    armv7*) arch="armv7" ;;
+  esac
+  echo ${arch}
+}
+uname_os_check() {
+  os=$(uname_os)
+  case "$os" in
+    darwin) return 0 ;;
+    dragonfly) return 0 ;;
+    freebsd) return 0 ;;
+
+    linux) return 0 ;;
+    android) return 0 ;;
+    nacl) return 0 ;;
+    netbsd) return 0 ;;
+    openbsd) return 0 ;;
+    plan9) return 0 ;;
+
+    solaris) return 0 ;;
+    windows) return 0 ;;
+
+  esac
+  log_crit "uname_os_check '$(uname -s)' got converted to '$os' which is not a GOOS value. Please file bug at https://github.com/client9/shlib"
+  return 1
+}
+uname_arch_check() {
+
+  arch=$(uname_arch)
+  case "$arch" in
+    386) return 0 ;;
+    amd64) return 0 ;;
+    arm64) return 0 ;;
+    armv5) return 0 ;;
+
+    armv6) return 0 ;;
+    armv7) return 0 ;;
+    ppc64) return 0 ;;
+    ppc64le) return 0 ;;
+    mips) return 0 ;;
+    mipsle) return 0 ;;
+    mips64) return 0 ;;
+    mips64le) return 0 ;;
+    s390x) return 0 ;;
+
+    amd64p32) return 0 ;;
+  esac
+  log_crit "uname_arch_check '$(uname -m)' got converted to '$arch' which is not a GOARCH value.  Please file bug report at https://github.com/client9/shlib"
+  return 1
+}
+untar() {
+
+  tarball=$1
+
+  case "${tarball}" in
+    *.tar.gz | *.tgz) tar --no-same-owner -xzf "${tarball}" ;;
+
+    *.tar) tar --no-same-owner -xf "${tarball}" ;;
+    *.zip) unzip "${tarball}" ;;
+    *)
+      log_err "untar unknown archive format for ${tarball}"
+      return 1
+      ;;
+  esac
+}
+http_download_curl() {
+  local_file=$1
+  source_url=$2
+  header=$3
+  if [ -z "$header" ]; then
+    code=$(curl -w '%{http_code}' -sL -o "$local_file" "$source_url")
+  else
+    code=$(curl -w '%{http_code}' -sL -H "$header" -o "$local_file" "$source_url")
+  fi
+  if [ "$code" != "200" ]; then
+    log_debug "http_download_curl received HTTP status $code"
+
+    return 1
+  fi
+  return 0
+}
+
+http_download_wget() {
+  local_file=$1
+  source_url=$2
+  header=$3
+  if [ -z "$header" ]; then
+    wget -q -O "$local_file" "$source_url"
+  else
+    wget -q --header "$header" -O "$local_file" "$source_url"
+  fi
+
+}
+http_download() {
+  log_debug "http_download $2"
+  if is_command curl; then
+    http_download_curl "$@"
+    return
+  elif is_command wget; then
+    http_download_wget "$@"
+    return
+  fi
+  log_crit "http_download unable to find wget or curl"
+  return 1
+}
+http_copy() {
+  tmp=$(mktemp)
+  http_download "${tmp}" "$1" "$2" || return 1
+  body=$(cat "$tmp")
+  rm -f "${tmp}"
+  echo "$body"
+}
+github_release() {
+
+  owner_repo=$1
+  version=$2
+  test -z "$version" && version="latest"
+  giturl="https://github.com/${owner_repo}/releases/${version}"
+  json=$(http_copy "$giturl" "Accept:application/json")
+  test -z "$json" && return 1
+  version=$(echo "$json" | tr -s '\n' ' ' | sed 's/.*"tag_name":"//' | sed 's/".*//')
+  test -z "$version" && return 1
+  echo "$version"
+}
+hash_sha256() {
+  TARGET=${1:-/dev/stdin}
+  if is_command gsha256sum; then
+    hash=$(gsha256sum "$TARGET") || return 1
+    echo "$hash" | cut -d ' ' -f 1
+  elif is_command sha256sum; then
+    hash=$(sha256sum "$TARGET") || return 1
+    echo "$hash" | cut -d ' ' -f 1
+  elif is_command shasum; then
+    hash=$(shasum -a 256 "$TARGET" 2>/dev/null) || return 1
+
+    echo "$hash" | cut -d ' ' -f 1
+  elif is_command openssl; then
+    hash=$(openssl -dst openssl dgst -sha256 "$TARGET") || return 1
+
+    echo "$hash" | cut -d ' ' -f a
+  else
+    log_crit "hash_sha256 unable to find command to compute sha-256 hash"
+    return 1
+  fi
+
+}
+hash_sha256_verify() {
+  TARGET=$1
+
+  checksums=$2
+  if [ -z "$checksums" ]; then
+    log_err "hash_sha256_verify checksum file not specified in arg2"
+    return 1
+  fi
+
+  BASENAME=${TARGET##*/}
+  want=$(grep "${BASENAME}" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
+  if [ -z "$want" ]; then
+
+    log_err "hash_sha256_verify unable to find checksum for '${TARGET}' in '${checksums}'"
+    return 1
+  fi
+  got=$(hash_sha256 "$TARGET")
+  if [ "$want" != "$got" ]; then
+    log_err "hash_sha256_verify checksum for '$TARGET' did not verify ${want} vs $got"
+    return 1
+  fi
+}
+
+cat /dev/null <<EOF
+------------------------------------------------------------------------
+End of functions from https://github.com/client9/shlib
+------------------------------------------------------------------------
+EOF
+
+
+PROJECT_NAME="deepsource"
+OWNER=deepsourcelabs
+REPO="cli"
+BINARY=deepsource
+FORMAT=tar.gz
+OS=$(uname_os)
+ARCH=$(uname_arch)
+PREFIX="$OWNER/$REPO"
+
+
+# use in logging routines
+
+log_prefix() {
+	echo "$PREFIX"
+
+}
+PLATFORM="${OS}/${ARCH}"
+GITHUB_DOWNLOAD=https://github.com/${OWNER}/${REPO}/releases/download
+
+
+uname_os_check "$OS"
+uname_arch_check "$ARCH"
+
+parse_args "$@"
+
+get_binaries
+
+tag_to_version
+
+
+adjust_format
+
+adjust_os
+
+adjust_arch
+
+log_info "found version: ${VERSION} for ${TAG}/${OS}/${ARCH}"
+
+# check_vars checks environment variables and determines the version of the CLI to be pulled.
+check_vars()
+{
+    ci_vars_count=0
+    var_names=("$@")
+    for var_name in "${var_names[@]}"; do
+        if [ ! -z "${!var_name}" ]; then
+          log_info "$var_name has the value: ${!var_name}"
+          ((ci_vars_count=ci_vars_count+1))
+        fi
+    done
+
+    # only display logs if env vars are found.
+    if [[ "$ci_vars_count" -gt 0 ]]; then
+    log_info "Found ${ci_vars_count} env vars related to CI."
+    fi
+
+    # if there are 1 or more env vars, use the deepsource_tcv version
+    if [[ "$ci_vars_count" -gt 0 ]]; then
+      NAME=${PROJECT_NAME}_tcv_${VERSION}_${OS}_${ARCH}
+      log_info "CI server detected. Pulling lightweight version of the CLI."
+    else
+      NAME=${PROJECT_NAME}_${VERSION}_${OS}_${ARCH}
+    fi
+}
+
+# check for these environment variables (CI)
+# https://github.com/watson/ci-info/blob/master/vendors.json
+check_vars APPVEYOR SYSTEM_TEAMFOUNDATIONCOLLECTIONURI AC_APPCIRCLE bamboo_planKey BITBUCKET_COMMIT BITRISE_IO BUDDY_WORKSPACE_ID BUILDKITE CI CIRCLECI CIRRUS_CI CODEBUILD_BUILD_ARN CF_BUILD_ID CI_NAME DRONE DSARI EAS_BUILD GITHUB_ACTIONS GITLAB_CI GO_PIPELINE_LABEL LAYERCI HUDSON_URL JENKINS_URL MAGNUM NETLIFY NEVERCODE RENDER SAILCI SEMAPHORE SCREWDRIVER SHIPPABLE TDDIUM STRIDER TEAMCITY_VERSION TRAVIS NOW_BUILDER APPCENTER_BUILD_ID
+
+TARBALL=${NAME}.${FORMAT}
+
+TARBALL_URL=${GITHUB_DOWNLOAD}/${TAG}/${TARBALL}
+
+CHECKSUM=checksums.txt
+CHECKSUM_URL=${GITHUB_DOWNLOAD}/${TAG}/${CHECKSUM}
+
+execute


### PR DESCRIPTION
This PR adds support for packaging the CLI into two binaries:

- `deepsource_tcv`: For CI servers, only test coverage reporting is included (~70% reduction in binary size; faster CI pipeline exec time)
- `deepsource`: The standard version of the CLI; includes all features

Closes: https://github.com/deepsourcelabs/cli/issues/165.

Screencast: https://asciinema.org/a/WtDzmguEZ1T4f11Z0BkUYX7Z3