### PR TITLE
chore: add `--skip-verify` flag to skip SSL certificates verification while reporting test coverage

### DIFF
--- a/command/report/query.go
+++ b/command/report/query.go
@@ -2,6 +2,7 @@ package report
 
 import (
 	"bytes"
+	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -10,11 +11,21 @@ import (
 )
 
 // makeQuery makes a HTTP query with a specified body and returns the response
-func makeQuery(url string, body []byte, bodyMimeType string) ([]byte, error) {
+func makeQuery(url string, body []byte, bodyMimeType string, skipCertificateVerification bool) ([]byte, error) {
 	var resBody []byte
-
 	httpClient := &http.Client{
 		Timeout: time.Second * 60,
+	}
+
+	if skipCertificateVerification {
+		// Create a custom HTTP Transport for skipping verification of SSL certificates
+		// if `--skip-verify` flag is passed.
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		}
+		httpClient.Transport = tr
 	}
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))

--- a/command/report/report.go
+++ b/command/report/report.go
@@ -16,10 +16,11 @@ import (
 )
 
 type ReportOptions struct {
-	Analyzer  string
-	Key       string
-	Value     string
-	ValueFile string
+	Analyzer                    string
+	Key                         string
+	Value                       string
+	ValueFile                   string
+	SkipCertificateVerification bool
 }
 
 // NewCmdVersion returns the current version of cli being used
@@ -59,6 +60,9 @@ func NewCmdReport() *cobra.Command {
 	cmd.Flags().StringVar(&opts.ValueFile, "value-file", "", "Path to the value file")
 
 	cmd.Flags().StringVar(&opts.Value, "value", "", "Value of the artifact")
+
+	// --skip-verify flag to skip SSL certificate verification while reporting test coverage data.
+	cmd.Flags().BoolVar(&opts.SkipCertificateVerification, "skip-verify", false, "Skip SSL certificate verification while sending the test coverage data")
 
 	return cmd
 }
@@ -227,6 +231,7 @@ func (opts *ReportOptions) Run() int {
 		dsnProtocol+"://"+dsnHost+"/graphql/cli/",
 		queryBodyBytes,
 		"application/json",
+		opts.SkipCertificateVerification,
 	)
 	if err != nil {
 		fmt.Println("DeepSource | Error | Reporting failed | ", err)

--- a/command/report/tests/init_test.go
+++ b/command/report/tests/init_test.go
@@ -30,7 +30,7 @@ func startMockAPIServer() {
 
 	go func() {
 		err := srv.ListenAndServe()
-		if err != nil {
+		if err != nil && err != http.ErrServerClosed {
 			panic(fmt.Sprintf("failed to start HTTP mock server with error=%s", err))
 		}
 	}()

--- a/command/report/tests/init_test.go
+++ b/command/report/tests/init_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -30,7 +31,7 @@ func startMockAPIServer() {
 	go func() {
 		err := srv.ListenAndServe()
 		if err != nil {
-			log.Fatalln("Error starting HTTP mock server")
+			panic(fmt.Sprintf("failed to start HTTP mock server with error=%s", err))
 		}
 	}()
 }

--- a/deepsource/tests/init_test.go
+++ b/deepsource/tests/init_test.go
@@ -30,7 +30,7 @@ func startMockAPIServer() {
 
 	go func() {
 		err := srv.ListenAndServe()
-		if err != nil {
+		if err != nil && err != http.ErrServerClosed {
 			panic(fmt.Sprintf("failed to start HTTP mock server with error=%s", err))
 		}
 	}()

--- a/deepsource/tests/init_test.go
+++ b/deepsource/tests/init_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -30,7 +31,7 @@ func startMockAPIServer() {
 	go func() {
 		err := srv.ListenAndServe()
 		if err != nil {
-			panic("Error starting HTTP mock server")
+			panic(fmt.Sprintf("failed to start HTTP mock server with error=%s", err))
 		}
 	}()
 }


### PR DESCRIPTION
Signed-off-by: Siddhant N Trivedi <siddhant@deepsource.io>