### PR TITLE
feat: Whitelist keys for Swift and Kotlin

### DIFF
--- a/command/report/report.go
+++ b/command/report/report.go
@@ -114,6 +114,8 @@ func (opts *ReportOptions) Run() int {
 		"csharp":     true,
 		"cxx":        true,
 		"rust":       true,
+		"swift":      true,
+		"kotlin":     true,
 	}
 
 	allowedKeys := func(m map[string]bool) []string {


### PR DESCRIPTION
This is required for adding their support in the test-coverage analyzer.