### PR TITLE
feat(issues): add severity filtering support to list command

### DIFF
--- a/command/issues/list/list.go
+++ b/command/issues/list/list.go
@@ -40,7 +40,6 @@ func NewCmdIssuesList() *cobra.Command {
 		RepoArg:  "",
 		LimitArg: 30,
 	}
-	// TODO:: add severity feature specifics here
 	doc := heredoc.Docf(`
         List issues reported by DeepSource.
 
@@ -204,19 +203,20 @@ func (opts *IssuesListOptions) getIssuesData(ctx context.Context) (err error) {
 		// set fetched issues as issue data
 		opts.issuesData = getUniqueIssues(fetchedIssues)
 	}
-	if len(opts.SeverityArg) != 0 {
-		//now we have some flag in the severity arg section use this and filter only those issues
-		var fetchedIssues []issues.Issue
 
+	if len(opts.SeverityArg) != 0 {
+		var fetchedIssues []issues.Issue
+		//Filter issues based on the severity option specified
 		filteredIssues, err = filterIssuesBySeverity(opts.SeverityArg, opts.issuesData)
 		if err != nil {
 			return err
 		}
 		fetchedIssues = append(fetchedIssues, filteredIssues...)
-
+		// set fetched issues as issue data
 		opts.issuesData = getUniqueIssues(fetchedIssues)
 
 	}
+
 	return nil
 }
 

--- a/command/issues/list/list_test.go
+++ b/command/issues/list/list_test.go
@@ -157,3 +157,75 @@ func TestFilterIssuesByAnalyzer(t *testing.T) {
 		}
 	})
 }
+
+func TestFilterIssuesBySeverity(t *testing.T) {
+	// Path to the dedicated severity test data
+	testDataPath := "./testdata/dummy/issues_severity.json"
+
+	// Case 1: Filter by a single severity
+	t.Run("must work with a single severity", func(t *testing.T) {
+		issues_data := ReadIssues(testDataPath)
+		// Testing lowercase "critical" to verify the ToUpper normalization logic
+		got, err := filterIssuesBySeverity([]string{"critical"}, issues_data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Expecting only the one CRITICAL issue defined in our JSON
+		if len(got) != 1 || strings.ToUpper(got[0].IssueSeverity) != "CRITICAL" {
+			t.Errorf("got: %v; expected 1 CRITICAL issue", got)
+		}
+	})
+
+	// Case 2: Filter by multiple severities simultaneously (Logical OR)
+	t.Run("must work with multiple severities", func(t *testing.T) {
+		issues_data := ReadIssues(testDataPath)
+
+		// Should return both MAJOR and MINOR issues
+		got, err := filterIssuesBySeverity([]string{"MAJOR", "MINOR"}, issues_data)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(got) != 2 {
+			t.Errorf("got: %d issues; want 2", len(got))
+		}
+	})
+
+	// Case 3: Handle invalid severity strings
+	t.Run("must return error for invalid severity input", func(t *testing.T) {
+		issues_data := ReadIssues(testDataPath)
+
+		// Verifying that the validator catches illegal entries
+		_, err := filterIssuesBySeverity([]string{"invalid_level"}, issues_data)
+		if err == nil {
+			t.Error("expected error for invalid severity 'invalid_level', got nil")
+		}
+	})
+
+	// Case 4: Handle valid severity that has no matches in the data
+	t.Run("must return empty list when no matches exist", func(t *testing.T) {
+		// Create a subset with only MINOR issues
+		subset := []issues.Issue{{IssueSeverity: "MINOR"}}
+
+		// Filtering for CRITICAL should yield 0 results but NO error
+		got, err := filterIssuesBySeverity([]string{"CRITICAL"}, subset)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(got) != 0 {
+			t.Errorf("expected 0 issues, got %d", len(got))
+		}
+	})
+
+	t.Run("should handle duplicate severity flags gracefully", func(t *testing.T) {
+		issues_data := ReadIssues(testDataPath)
+
+		got, _ := filterIssuesBySeverity([]string{"critical", "critical"}, issues_data)
+		if len(got) != 1 {
+			t.Errorf("expected 1 issue despite duplicate flag, got %d", len(got))
+		}
+	})
+}

--- a/command/issues/list/testdata/dummy/issues_severity.json
+++ b/command/issues/list/testdata/dummy/issues_severity.json
@@ -1,0 +1,23 @@
+[
+  {
+    "issue_title": "Critical Security Bug",
+    "issue_code": "SEC-001",
+    "issue_severity": "CRITICAL",
+    "location": { "path": "main.go", "position": { "begin": 10, "end": 10 } },
+    "Analyzer": { "analyzer": "go" }
+  },
+  {
+    "issue_title": "Major Performance Issue",
+    "issue_code": "PERF-002",
+    "issue_severity": "MAJOR",
+    "location": { "path": "utils.go", "position": { "begin": 20, "end": 20 } },
+    "Analyzer": { "analyzer": "go" }
+  },
+  {
+    "issue_title": "Minor Style Nitpick",
+    "issue_code": "STYLE-003",
+    "issue_severity": "MINOR",
+    "location": { "path": "list.go", "position": { "begin": 30, "end": 30 } },
+    "Analyzer": { "analyzer": "go" }
+  }
+]

--- a/command/issues/list/utils.go
+++ b/command/issues/list/utils.go
@@ -33,6 +33,7 @@ func filterIssuesByPath(path string, issuesData []issues.Issue) ([]issues.Issue,
 		// get relative path
 		rel, err := filepath.Rel(path, issue.Location.Path)
 		if err != nil {
+
 			return nil, err
 		}
 
@@ -55,14 +56,26 @@ func filterIssuesByPath(path string, issuesData []issues.Issue) ([]issues.Issue,
 func filterIssuesBySeverity(severity []string, issuesData []issues.Issue) ([]issues.Issue, error) {
 	var filteredIssues []issues.Issue
 
-	// Create a map for quick lookup of severities
-	severityMap := make(map[string]bool)
-	for _, s := range severity {
-		severityMap[strings.ToUpper(s)] = true // Ensure case-insensitivity
+	// valid options for severity
+	validSeverities := map[string]bool{
+		"CRITICAL": true,
+		"MAJOR":    true,
+		"MINOR":    true,
 	}
 
+	//  Validate user input and normalize to uppercase
+	severityMap := make(map[string]bool)
+	for _, s := range severity {
+		upperS := strings.ToUpper(s)
+		if !validSeverities[upperS] {
+			return nil, fmt.Errorf("invalid severity level: %s (valid options: CRITICAL, MAJOR, MINOR)", s)
+		}
+		severityMap[upperS] = true
+	}
+
+	//  Filter the issues list
 	for _, issue := range issuesData {
-		// Match against the IssueSeverity field from the SDK struct
+		//match against the IssueSeverity field from the SDK Issue Struct
 		if severityMap[strings.ToUpper(issue.IssueSeverity)] {
 			filteredIssues = append(filteredIssues, issue)
 		}


### PR DESCRIPTION
Description:
#247 Filter issues by severity

This PR adds a `--severity` (shorthand `-s`) flag to the `issues list` command, allowing users to filter issues by severity directly from the CLI. This improves issue triage by enabling developers to quickly surface high-priority findings without additional post-processing.

Key Changes:
- Added `SeverityArg` to `IssuesListOptions` and wired it to the `issues list` command with shorthand `-s`.
- Implemented `filterIssuesBySeverity` in `utils.go`.
  - Supports multiple severity flags (e.g. `--severity critical --severity major`) using OR semantics.

Validation & Normalization:
- Validates user input against supported DeepSource severities: `CRITICAL`, `MAJOR`, `MINOR`.
- Normalizes both user input and API values to uppercase to ensure case-insensitive matching.

Testing:
- Added unit tests for severity filtering in `list_test.go`, covering:
  - Single and multiple severity filters
  - Invalid severity input handling
  - Duplicate severity flags
- Introduced isolated mock data at `testdata/dummy/issues_severity.json` to avoid coupling with existing fixtures.
