### PR TITLE
fix(ENG-4699): use run query on PR fallback in metrics & vulnerabilities

### DIFF
--- a/command/metrics/metrics.go
+++ b/command/metrics/metrics.go
@@ -253,7 +253,11 @@ func (opts *MetricsOptions) resolveMetrics(ctx context.Context, client *deepsour
 		case ab.PRNumber > 0:
 			opts.PRNumber = ab.PRNumber
 			opts.CommitOid = ab.CommitOid
-			opts.prMetrics, err = client.GetPRMetrics(ctx, remote.Owner, remote.RepoName, remote.VCSProvider, ab.PRNumber)
+			if ab.Fallback {
+				opts.runMetrics, err = client.GetRunMetrics(ctx, ab.CommitOid)
+			} else {
+				opts.prMetrics, err = client.GetPRMetrics(ctx, remote.Owner, remote.RepoName, remote.VCSProvider, ab.PRNumber)
+			}
 		case ab.UseRepo:
 			opts.repoMetrics, err = client.GetRepoMetrics(ctx, remote.Owner, remote.RepoName, remote.VCSProvider)
 		default:

--- a/command/vulnerabilities/vulnerabilities.go
+++ b/command/vulnerabilities/vulnerabilities.go
@@ -241,7 +241,11 @@ func (opts *VulnerabilitiesOptions) resolveVulnerabilities(ctx context.Context, 
 		case ab.PRNumber > 0:
 			opts.PRNumber = ab.PRNumber
 			opts.CommitOid = ab.CommitOid
-			opts.prVulns, err = client.GetPRVulns(ctx, remote.Owner, remote.RepoName, remote.VCSProvider, ab.PRNumber)
+			if ab.Fallback {
+				opts.runVulns, err = client.GetRunVulns(ctx, ab.CommitOid)
+			} else {
+				opts.prVulns, err = client.GetPRVulns(ctx, remote.Owner, remote.RepoName, remote.VCSProvider, ab.PRNumber)
+			}
 		case ab.UseRepo:
 			opts.repoVulns, err = client.GetRepoVulns(ctx, remote.Owner, remote.RepoName, remote.VCSProvider)
 		default:


### PR DESCRIPTION
## Summary

When auto-branch resolution detects a PR but the current run is still in progress, the CLI falls back to the last completed run. On the PR path, the `metrics` and `vulnerabilities` commands unconditionally queried the PR-scoped endpoints (`GetPRMetrics` / `GetPRVulns`), which return empty until the run completes — so users saw empty results on fallback.

This switches to the run-scoped query (`GetRunMetrics` / `GetRunVulns`) with the fallback commit OID when `ab.Fallback` is true, matching the existing behavior in `issues.go` and the non-PR fallback path.

Sibling fix to ENG-4240 (issues command).

## Changes

- `command/metrics/metrics.go` — use `GetRunMetrics` on fallback
- `command/vulnerabilities/vulnerabilities.go` — use `GetRunVulns` on fallback

## Notes

Downstream render/JSON/header paths already branch on `runMetrics`/`runVulns` first, so output renders correctly on fallback.

Closes ENG-4699

🤖 Generated with [Claude Code](https://claude.com/claude-code)
